### PR TITLE
hoodle-core: make Haddock work

### DIFF
--- a/hoodle-core/src/Hoodle/Coroutine/Default/Menu.hs
+++ b/hoodle-core/src/Hoodle/Coroutine/Default/Menu.hs
@@ -133,13 +133,8 @@ menuEventProcess MenuUseXInput = do
     let cmap = view cvsInfoMap uhdl
         canvases = map (getDrawAreaFromBox) . M.elems $ cmap 
     updateFlagFromToggleUI "UXINPUTA" (settings.doesUseXInput) >>= \b -> 
-    -- #ifdef GTK3      
       return ()
-    -- #else
-    --   if b
-    --     then mapM_ (\x->liftIO $ Gtk.widgetSetExtensionEvents x [Gtk.ExtensionEventsAll]) canvases
-    --     else mapM_ (\x->liftIO $ Gtk.widgetSetExtensionEvents x [Gtk.ExtensionEventsNone] ) canvases
-    -- #endif
+
 menuEventProcess MenuUseTouch = toggleTouch
 menuEventProcess MenuUsePopUpMenu = updateFlagFromToggleUI "POPMENUA" (settings.doesUsePopUpMenu) >> return ()
 menuEventProcess MenuEmbedImage = updateFlagFromToggleUI "EBDIMGA" (settings.doesEmbedImage) >> return ()
@@ -206,10 +201,6 @@ colorConvert (Gtk.Color r g b) = ColorRGBA (realToFrac r/65536.0) (realToFrac g/
 -- | 
 colorPickerBox :: String -> MainCoroutine (Maybe PenColor) 
 colorPickerBox msg = do 
-    -- #ifdef GTK3 
-    -- color selection dialog is incomplete in gtk3
-    -- return Nothing
-    -- #else
     xst <- get 
     let pcolor = view (penInfo.currentTool.penColor) xst   
     doIOaction (action pcolor) >> go

--- a/hoodle-core/src/Hoodle/Coroutine/Dialog.hs
+++ b/hoodle-core/src/Hoodle/Coroutine/Dialog.hs
@@ -71,15 +71,9 @@ textInputDialog msg = do
     doIOaction $ \_evhandler -> do 
                    dialog <- Gtk.messageDialogNew Nothing [Gtk.DialogModal]
                      Gtk.MessageQuestion Gtk.ButtonsOkCancel msg
-                   -- #ifdef GTK3
                    vbox <- fmap Gtk.castToContainer (Gtk.dialogGetContentArea dialog)
                    txtvw <- Gtk.textViewNew
                    Gtk.containerAdd vbox txtvw  
-                   -- #else 
-                   -- vbox <- Gtk.dialogGetUpper dialog
-                   -- txtvw <- Gtk.textViewNew
-                   -- Gtk.boxPackStart vbox txtvw Gtk.PackGrow 0 
-                   -- #endif
                    Gtk.widgetShowAll dialog
                    res <- Gtk.dialogRun dialog 
                    case res of 
@@ -108,13 +102,9 @@ keywordDialog keylst = do
 keywordDialog' :: [T.Text] -> (AllEvent -> IO ()) -> IO AllEvent
 keywordDialog' keys = \_evhandler -> do
     dialog <- Gtk.dialogNew
-    -- #ifdef GTK3
     upper <- fmap Gtk.castToContainer (Gtk.dialogGetContentArea dialog)
     vbox <- Gtk.vBoxNew False 0 
     Gtk.containerAdd upper vbox
-    -- #else
-    -- vbox <- Gtk.dialogGetUpper dialog
-    -- #endif
     hbox <- Gtk.hBoxNew False 0
     Gtk.boxPackStart vbox hbox Gtk.PackNatural 0
     _btnOk <- Gtk.dialogAddButton dialog ("Ok" :: String) Gtk.ResponseOk
@@ -148,13 +138,9 @@ longTextMessageBox msg = action
     action = doIOaction $ 
                \_evhandler -> do 
                  dialog <- Gtk.dialogNew
-                 -- #ifdef GTK3
                  upper <- fmap Gtk.castToContainer (Gtk.dialogGetContentArea dialog)
                  vbox <- Gtk.vBoxNew False 0 
                  Gtk.containerAdd upper vbox
-                 -- #else
-                 -- vbox <- Gtk.dialogGetUpper dialog
-                 -- #endif
                  hbox <- Gtk.hBoxNew False 0
                  txtbuf <- Gtk.textBufferNew Nothing
                  Gtk.textBufferSetText txtbuf msg

--- a/hoodle-core/src/Hoodle/Coroutine/Draw.hs
+++ b/hoodle-core/src/Hoodle/Coroutine/Draw.hs
@@ -211,17 +211,9 @@ invalidateTemp cid tempsurface rndr = do
       let canvas = view drawArea cvsInfo
           pnum = PageNum . view currentPageNum $ cvsInfo 
       geometry <- liftIO $ getCanvasGeometryCvsId cid uhdl
-      -- #ifdef GTK3          
       Just win <- liftIO $ Gtk.widgetGetWindow canvas
-      -- #else
-      -- win <- liftIO $ Gtk.widgetGetDrawWindow canvas
-      -- #endif 
       let xformfunc = cairoXform4PageCoordinate (mkXform4Page geometry pnum)
-      -- #ifdef GTK3              
       liftIO $ Gtk.renderWithDrawWindow win $ do 
-      -- #else 
-      -- liftIO $ Gtk.renderWithDrawable win $ do   
-      -- #endif
                  Cairo.setSourceSurface tempsurface 0 0 
                  Cairo.setOperator Cairo.OperatorSource 
                  Cairo.paint 
@@ -243,17 +235,9 @@ invalidateTempBasePage cid tempsurface pnum rndr = do
     fsingle uhdl cvsInfo = do 
       let canvas = view drawArea cvsInfo
       geometry <- liftIO $ getCanvasGeometryCvsId cid uhdl
-      -- #ifdef GTK3          
       Just win <- liftIO $ Gtk.widgetGetWindow canvas
-      -- #else
-      -- win <- liftIO $ Gtk.widgetGetDrawWindow canvas
-      -- #endif
       let xformfunc = cairoXform4PageCoordinate (mkXform4Page geometry pnum)
-      -- #ifdef GTK3              
       liftIO $ Gtk.renderWithDrawWindow win $ do   
-      -- #else 
-      -- liftIO $ Gtk.renderWithDrawable win $ do   
-      -- #endif
                  Cairo.setSourceSurface tempsurface 0 0 
                  Cairo.setOperator Cairo.OperatorSource 
                  Cairo.paint 

--- a/hoodle-core/src/Hoodle/Coroutine/File.hs
+++ b/hoodle-core/src/Hoodle/Coroutine/File.hs
@@ -643,13 +643,9 @@ showRevisionDialog hdl revs = do
   where 
     action (cache,cvsid) _evhandler = do 
       dialog <- Gtk.dialogNew
-      -- #ifdef GTK3
       upper <- fmap Gtk.castToContainer (Gtk.dialogGetContentArea dialog)
       vbox <- Gtk.vBoxNew False 0
       Gtk.containerAdd upper vbox 
-      -- #else 
-      -- vbox <- Gtk.dialogGetUpper dialog
-      -- #endif
       mapM_ (addOneRevisionBox cache cvsid vbox hdl) revs 
       _btnOk <- Gtk.dialogAddButton dialog ("Ok" :: String) Gtk.ResponseOk
       Gtk.widgetShowAll dialog
@@ -682,16 +678,8 @@ addOneRevisionBox cache cvsid vbox hdl rev = do
     cvs <- Gtk.drawingAreaNew 
     cvs `Gtk.on` Gtk.sizeRequest $ return (Gtk.Requisition 250 25)
     cvs `Gtk.on` Gtk.exposeEvent $ Gtk.tryEvent $ do 
-      -- #ifdef GTK3      
       Just drawwdw <- liftIO $ Gtk.widgetGetWindow cvs 
-      -- #else
-      -- drawwdw <- liftIO $ Gtk.widgetGetDrawWindow cvs 
-      -- #endif
-      -- #ifdef GTK3
       liftIO . Gtk.renderWithDrawWindow drawwdw $ do
-      -- #else 
-      -- liftIO . Gtk.renderWithDrawable drawwdw $ do 
-      -- #endif
         case rev of 
           RevisionInk _ strks -> Cairo.scale 0.5 0.5 >> mapM_ (cairoRender cache cvsid) strks
           Revision _ txt -> mkPangoText (B.unpack txt)            

--- a/hoodle-core/src/Hoodle/Coroutine/HandwritingRecognition.hs
+++ b/hoodle-core/src/Hoodle/Coroutine/HandwritingRecognition.hs
@@ -101,13 +101,9 @@ showRecogTextDialog txts = do
   where 
     action = \evhandler -> do 
                dialog <- Gtk.dialogNew
-               -- #ifdef GTK3
                upper <- fmap Gtk.castToContainer (Gtk.dialogGetContentArea dialog)
                vbox <- Gtk.vBoxNew False 0        
                Gtk.containerAdd upper vbox
-               -- #else
-               -- vbox <- Gtk.dialogGetUpper dialog
-               -- #endif
                let txtlst' = zip [1..] txts
                txtlst <- forM txtlst' $ \(n,txt) -> do
                  let str = T.unpack txt 

--- a/hoodle-core/src/Hoodle/Coroutine/Link.hs
+++ b/hoodle-core/src/Hoodle/Coroutine/Link.hs
@@ -266,13 +266,9 @@ addLink = do
   where 
     action mfn = do  dialog <- Gtk.messageDialogNew Nothing [Gtk.DialogModal]
                                  Gtk.MessageQuestion Gtk.ButtonsOkCancel ("add link" :: String)
-                     -- #ifdef GTK3                               
                      upper <- fmap Gtk.castToContainer (Gtk.dialogGetContentArea dialog)
                      vbox <- Gtk.vBoxNew False 0
                      Gtk.containerAdd upper vbox
-                     -- #else
-                     -- vbox <- Gtk.dialogGetUpper dialog
-                     -- #endif
                      txtvw <- Gtk.textViewNew
                      Gtk.boxPackStart vbox txtvw Gtk.PackGrow 0 
                      Gtk.widgetShowAll dialog

--- a/hoodle-core/src/Hoodle/Coroutine/Minibuffer.hs
+++ b/hoodle-core/src/Hoodle/Coroutine/Minibuffer.hs
@@ -76,16 +76,8 @@ minibufDialog msg = do
       cvs <- Gtk.drawingAreaNew                           
       cvs `Gtk.on` Gtk.sizeRequest $ return (Gtk.Requisition 500 50)
       cvs `Gtk.on` Gtk.exposeEvent $ Gtk.tryEvent $ do
-        -- #ifdef GTK3        
         Just drawwdw <- liftIO $ Gtk.widgetGetWindow cvs
-        -- #else
-        -- drawwdw <- liftIO $ Gtk.widgetGetDrawWindow cvs                 
-        -- #endif
-        -- #ifdef GTK3
         liftIO (Gtk.renderWithDrawWindow drawwdw drawMiniBufBkg)
-        -- #else
-        -- liftIO (Gtk.renderWithDrawable drawwdw drawMiniBufBkg)
-        -- #endif
         (liftIO . evhandler . UsrEv . MiniBuffer . MiniBufferInitialized) drawwdw
       cvs `Gtk.on` Gtk.buttonPressEvent $ Gtk.tryEvent $ do 
         (mbtn,mp) <- getPointer dev
@@ -109,14 +101,9 @@ minibufDialog msg = do
               TouchButton -> return () 
               _ -> (liftIO . evhandler . UsrEv . MiniBuffer) (MiniBufferPenMove p)
       Gtk.widgetAddEvents cvs [Gtk.PointerMotionMask,Gtk.Button1MotionMask]
-      --
-      -- #ifdef GTK3
       upper <- fmap Gtk.castToContainer (Gtk.dialogGetContentArea dialog)
       vbox <- Gtk.vBoxNew False 0 
       Gtk.containerAdd upper vbox
-      -- #else 
-      -- vbox <- Gtk.dialogGetUpper dialog
-      -- #endif
       hbox <- Gtk.hBoxNew False 0 
       Gtk.boxPackStart hbox msgLabel Gtk.PackNatural 0 
       Gtk.boxPackStart vbox hbox Gtk.PackNatural 0
@@ -148,11 +135,7 @@ minibufInit =
 
 invalidateMinibuf :: Gtk.DrawWindow -> Cairo.Surface -> IO ()
 invalidateMinibuf drawwdw tgtsfc = 
-  -- #ifdef GTK3
   Gtk.renderWithDrawWindow drawwdw $ do 
-  -- #else 
-  -- Gtk.renderWithDrawable drawwdw $ do 
-  -- #endif
     Cairo.setSourceSurface tgtsfc 0 0 
     Cairo.setOperator Cairo.OperatorSource 
     Cairo.paint

--- a/hoodle-core/src/Hoodle/Coroutine/TextInput.hs
+++ b/hoodle-core/src/Hoodle/Coroutine/TextInput.hs
@@ -89,13 +89,9 @@ import Prelude hiding (readFile,mapM_)
 multiLineDialog :: T.Text -> (AllEvent -> IO ()) -> IO AllEvent
 multiLineDialog str evhandler = do
     dialog <- Gtk.dialogNew
-    -- #ifdef GTK3    
     upper <- fmap Gtk.castToContainer (Gtk.dialogGetContentArea dialog)
     vbox <- Gtk.vBoxNew False 0
     Gtk.containerAdd upper vbox
-    -- #else 
-    -- vbox <- Gtk.dialogGetUpper dialog
-    -- #endif
     textbuf <- Gtk.textBufferNew Nothing
     Gtk.textBufferSetByteString textbuf (TE.encodeUtf8 str)
     textbuf `Gtk.on` Gtk.bufferChanged $ do 
@@ -496,13 +492,9 @@ textInputFromSource (x0,y0) = do
 linePosDialog :: Either (ActionOrder AllEvent) AllEvent
 linePosDialog = mkIOaction $ \_evhandler -> do
     dialog <- Gtk.dialogNew
-    -- #ifdef GTK3
     upper <- fmap Gtk.castToContainer (Gtk.dialogGetContentArea dialog)
     vbox <- Gtk.vBoxNew False 0 
     Gtk.containerAdd upper vbox
-    -- #else 
-    -- vbox <- Gtk.dialogGetUpper dialog
-    -- #endif
     hbox <- Gtk.hBoxNew False 0
     Gtk.boxPackStart vbox hbox Gtk.PackNatural 0
 

--- a/hoodle-core/src/Hoodle/Coroutine/VerticalSpace.hs
+++ b/hoodle-core/src/Hoodle/Coroutine/VerticalSpace.hs
@@ -243,16 +243,8 @@ verticalSpaceProcess cid geometry pinfo@(bbx,hltedLayers,pnum@(PageNum n),pg)
              Cairo.paint
              drawguide 
            let canvas = view drawArea cvsInfo 
-           -- #ifdef GTK3
            Just win <- liftIO $ Gtk.widgetGetWindow canvas
-           -- #else 
-           -- win <- liftIO $ Gtk.widgetGetDrawWindow canvas
-           -- #endif
-           -- #ifdef GTK3
            liftIO $ Gtk.renderWithDrawWindow win $ do 
-           -- #else 
-           -- liftIO $ Gtk.renderWithDrawable win $ do 
-           -- #endif
              Cairo.setSourceSurface sfctot 0 0 
              Cairo.setOperator Cairo.OperatorSource 
              Cairo.paint 

--- a/hoodle-core/src/Hoodle/Coroutine/Window.hs
+++ b/hoodle-core/src/Hoodle/Coroutine/Window.hs
@@ -220,12 +220,6 @@ switchTab tabnum = do
       liftIO $ Gtk.widgetSetSensitive (uhdl^.unitButton) True
       modify $ (unitHoodles.currentUnit .~ uhdl)
       updateUhdl $ \uhdl' -> liftIO (updatePageAll (view hoodleModeState uhdl') uhdl')
-      -- #ifndef GTK3
-      -- view currentCanvasInfo uhdl # 
-      --   forBoth' unboxBiAct $ \cinfo -> do
-      --    (w,h) <- liftIO $ Gtk.widgetGetSize (cinfo^.drawArea) 
-      --     doCanvasConfigure (cinfo^.canvasId) (CanvasDimension (Dim (fromIntegral w) (fromIntegral h)))
-      -- #endif
       invalidateAll 
       liftIO $ reflectUIToggle (xst ^. gtkUIManager) "SAVEA" (not (uhdl ^. isSaved))
       reflectPenModeUI

--- a/hoodle-core/src/Hoodle/GUI.hs
+++ b/hoodle-core/src/Hoodle/GUI.hs
@@ -69,12 +69,6 @@ startGUI mfname mhook = do
     setToggleUIForFlag "TOGGLENETSRCA" False st0
     -- 
     let canvases = map (getDrawAreaFromBox) . M.elems . view (unitHoodles.currentUnit.cvsInfoMap) $ st0
--- #ifndef GTK3      
---     if xinputbool
---         then mapM_ (flip Gtk.widgetSetExtensionEvents [Gtk.ExtensionEventsAll]) canvases
---         else mapM_ (flip Gtk.widgetSetExtensionEvents [Gtk.ExtensionEventsNone]) canvases
--- #endif
-    --
     outerLayout ui vbox st0 
     window `Gtk.on` Gtk.deleteEvent $ do
       liftIO $ eventHandler tref (UsrEv (Menu MenuQuit))

--- a/hoodle-core/src/Hoodle/GUI/Reflect.hs
+++ b/hoodle-core/src/Hoodle/GUI/Reflect.hs
@@ -187,11 +187,7 @@ reflectCursor isforced = do
                       else do let uhdl       = view (unitHoodles.currentUnit) xst
                                   cinfobox   = view currentCanvasInfo uhdl           
                                   canvas     = forBoth' unboxBiAct (view drawArea) cinfobox
-                              -- #ifdef GTK3
                               Just win <- Gtk.widgetGetWindow canvas
-                              -- #else
-                              -- win <- Gtk.widgetGetDrawWindow canvas
-                              -- #endif
                               Gtk.postGUIAsync (Gtk.drawWindowSetCursor win Nothing) 
                               return (UsrEv ActionOrdered)
  where 
@@ -208,11 +204,7 @@ reflectCursor isforced = do
          pinfo = view penInfo xst 
          pcolor = view (penSet . currPen . penColor) pinfo
          pwidth = view (penSet . currPen . penWidth) pinfo 
-     -- #ifdef GTK3
      Just win <- Gtk.widgetGetWindow canvas
-     -- #else
-     -- win <- Gtk.widgetGetDrawWindow canvas
-     -- #endif
      dpy <- Gtk.widgetGetDisplay canvas  
 
      geometry <- 

--- a/hoodle-core/src/Hoodle/ModelAction/Layer.hs
+++ b/hoodle-core/src/Hoodle/ModelAction/Layer.hs
@@ -49,13 +49,8 @@ layerChooseDialog layernumref cidx len = do
     Gtk.entrySetText layerentry (show (succ cidx))
     label <- Gtk.labelNew (Just (" / " ++ show len))
     hbox <- Gtk.hBoxNew False 0 
-    -- #ifdef GTK3    
     upper <- fmap Gtk.castToContainer (Gtk.dialogGetContentArea dialog)
     Gtk.containerAdd upper hbox
-    -- #else
-    --     upper <- Gtk.dialogGetUpper dialog
-    --     Gtk.boxPackStart upper hbox Gtk.PackNatural 0 
-    -- #endif
     Gtk.boxPackStart hbox layerentry Gtk.PackNatural 0 
     Gtk.boxPackStart hbox label Gtk.PackGrow 0 
     Gtk.widgetShowAll upper

--- a/hoodle-core/src/Hoodle/ModelAction/Window.hs
+++ b/hoodle-core/src/Hoodle/ModelAction/Window.hs
@@ -214,28 +214,6 @@ connectDefaultEventCanvasInfo xstate _uhdl cinfo = do
                       return False
     return $ cinfo { _horizAdjConnId = Just hadjconnid
                    , _vertAdjConnId = Just vadjconnid }
-    
-{-     
--- #ifdef GTK3
--- #endif
-    _sizereq <- canvas `Gtk.on` Gtk.sizeRequest $ return (Gtk.Requisition 800 400)
-
-
-#ifdef GTK3
-#else
-    _exposeev <- canvas `Gtk.on` Gtk.exposeEvent $ Gtk.tryEvent $ do 
-#endif
-#ifdef GTK3    
-#else
-    if b then Gtk.widgetSetExtensionEvents canvas [Gtk.ExtensionEventsAll]
-         else Gtk.widgetSetExtensionEvents canvas [Gtk.ExtensionEventsNone]
-#endif
--- #ifdef GTK3
-    -}
--- #endif
-
-    -- temp
-    return $ cinfo     
 
 -- | recreate windows from old canvas info but no event connect
 reinitCanvasInfoStage1 

--- a/hoodle-core/src/Hoodle/View/Coordinate.hs
+++ b/hoodle-core/src/Hoodle/View/Coordinate.hs
@@ -58,11 +58,7 @@ makeCanvasGeometry :: PageNum
                       -> Gtk.DrawingArea 
                       -> IO CanvasGeometry 
 makeCanvasGeometry cpn arr canvas = do 
-  -- #ifdef GTK3  
   Just win <- Gtk.widgetGetWindow canvas
-  -- #else
-  -- win <- Gtk.widgetGetDrawWindow canvas
-  -- #endif
   let cdim@(CanvasDimension (Dim w' h')) = view canvasDimension arr
   screen <- Gtk.widgetGetScreen canvas
   (ws,hs) <- (,) <$> (fromIntegral <$> Gtk.screenGetWidth screen)


### PR DESCRIPTION
Commented #ifdefs were causing the Haddock documentation generation to
fail.