### PR TITLE
Remove now missing packages from stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -10,9 +10,6 @@ packages:
 - hoodle/
 - hoodle-builder/
 - hoodle-core/
-- hoodle-daemon/
-- hoodle-extra/
-- hoodle-manage/
 - hoodle-parser/
 - hoodle-publish/
 - hoodle-render/


### PR DESCRIPTION
hoodle-daemon, hoodle-extra and hoodle-manage no longer exist