### PR TITLE
Quick-Fix NixOS build environment (nixos-17.03)

### DIFF
--- a/build-shell.nix
+++ b/build-shell.nix
@@ -7,7 +7,7 @@ let hsconfig = import ./default.nix { poppler = pkgs.poppler; gtk3 = pkgs.gtk3; 
                     #hoodle-types xournal-types coroutine-object
                     case-insensitive
                     attoparsec-conduit SHA aeson-pretty blaze-html hinotify zlib-conduit
-                    http-client-tls http-conduit handa-gdata xml fsnotify json pem pureMD5 
+                    http-client-tls http-conduit xml fsnotify json pem pureMD5 
                     regex-base regex-posix configurator http-types system-filepath
                     transformers-free websockets 
                     data-default-instances-containers asn1-parse 
@@ -15,7 +15,6 @@ let hsconfig = import ./default.nix { poppler = pkgs.poppler; gtk3 = pkgs.gtk3; 
                   ]);
  in pkgs.stdenv.mkDerivation { 
       name = "env-hoodle-build";
-      propagatedBuildInputs = [ pkgs.wrapGAppsHook ] ;
       buildInputs = [ hsenv pkgs.x11 pkgs.xlibs.libXi pkgs.gtk3 pkgs.poppler pkgs.pkgconfig
                       pkgs.gd pkgs.librsvg
                     ];

--- a/default.nix
+++ b/default.nix
@@ -1,31 +1,6 @@
 { poppler, gtk3 }:
 
 self: super: {
-   "gtk2hs-buildtools" = self.callPackage
-    ({ mkDerivation, alex, array, base, Cabal,
-       containers, directory
-     , filepath, happy, hashtables, pretty, process, random, stdenv
-     }:
-     mkDerivation {
-       pname = "gtk2hs-buildtools";
-       version = "0.13.2.1";
-       sha256 = "86ea21a2e07d83dcff57eb224a7c76835fb4ea561e4d6ba9b52b8035b38d064b";
-       isLibrary = true;
-       isExecutable = true;
-       libraryHaskellDepends = [
-         array base #Cabal
-         containers directory filepath hashtables pretty
-         process random
-       ];
-       libraryToolDepends = [ alex happy ];
-       executableHaskellDepends = [ base ];
-       homepage = "http://projects.haskell.org/gtk2hs/";
-       description = "Tools to build the Gtk2Hs suite of User Interface libraries";
-       license = stdenv.lib.licenses.gpl2;
-     }) {};
-  
-
-
   "poppler" = self.callPackage
   ({ mkDerivation, array, base, bytestring, cairo, containers
    , glib, gtk3, gtk3lib, gtk2hs-buildtools, mtl, pango, popplerlib
@@ -36,6 +11,7 @@ self: super: {
     version = "0.14.1";
 
     configureFlags = ["-fgtk3"];
+    hardeningDisable=["fortify"];
     libraryHaskellDepends = [
       array base bytestring cairo containers glib gtk3 mtl
     ];

--- a/hoodle-core/hoodle-core.cabal
+++ b/hoodle-core/hoodle-core.cabal
@@ -32,7 +32,7 @@ Flag Hub
 
 Library
   hs-source-dirs: src
-  ghc-options: 	-Wall -funbox-strict-fields -fno-warn-unused-do-bind -fno-warn-orphans 
+  ghc-options: 	-funbox-strict-fields -fno-warn-unused-do-bind -fno-warn-orphans 
   ghc-prof-options: -caf-all -auto-all
 
   Build-Depends:   base == 4.*, 

--- a/hoodle-core/src/Hoodle/Coroutine/HandwritingRecognition.hs
+++ b/hoodle-core/src/Hoodle/Coroutine/HandwritingRecognition.hs
@@ -80,7 +80,7 @@ handwritingRecognitionDialog = do
                   <=< getArrayVal 0 <=< getArrayVal 1) v0 
             let f (String v) = Just v
                 f _ = Nothing
-            (return . mapMaybe f . toList) v4
+            (return . Data.Maybe.mapMaybe f . toList) v4
       
           case r_parse of 
             Left err -> msgShout ("handwritingRecognitionDialog: " ++ err) >> return Nothing 

--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,7 @@ let hsconfig = import ./default.nix { poppler = pkgs.poppler; gtk3 = pkgs.gtk3; 
       (p: with p; [ hoodle-builder hoodle-render hoodle-publish xournal-parser
                     hoodle-types xournal-types coroutine-object case-insensitive
                     attoparsec-conduit SHA aeson-pretty blaze-html hinotify zlib-conduit
-                    http-client-tls http-conduit handa-gdata xml fsnotify json pem pureMD5 
+                    http-client-tls http-conduit xml fsnotify json pem pureMD5 
                     regex-base regex-posix configurator http-types system-filepath
                     transformers-free websockets 
                     data-default-instances-containers asn1-parse 
@@ -14,8 +14,7 @@ let hsconfig = import ./default.nix { poppler = pkgs.poppler; gtk3 = pkgs.gtk3; 
                   ]);
  in pkgs.stdenv.mkDerivation { 
       name = "env-hoodle-build";
-      propagatedBuildInputs = [ pkgs.wrapGAppsHook ] ;
-      buildInputs = [ hsenv pkgs.x11 pkgs.xlibs.libXi pkgs.gtk3 pkgs.poppler pkgs.pkgconfig
+      buildInputs = [ hsenv pkgs.haskellPackages.cabal-install pkgs.x11 pkgs.xlibs.libXi pkgs.gtk3 pkgs.poppler pkgs.pkgconfig
                     ];
       shellHook = ''
       '';


### PR DESCRIPTION
These patches make it possible to build and use hoodle within nix-shell.

I've haven't thoroughly tested hoodle with these changes, because I run NixOS in a VM which is not setup for Xinput nor do I know the normal behaviour of hoodle.

A proper fix would be to replace the deprecated gtk3 functions such that `-Wall` compiler can be re-enabled.