### PR TITLE
hoodle-parser: switch from deprecated+removed Control.Monad.Trans.Except

### DIFF
--- a/hoodle-builder/hoodle-builder.cabal
+++ b/hoodle-builder/hoodle-builder.cabal
@@ -24,7 +24,7 @@ Library
                    bytestring >= 0.9, 
                    double-conversion >= 0.2.0.6,
                    hoodle-types >= 0.4,
-                   lens >= 2.5,
+                   microlens >= 0.4,
                    strict >= 0.3, 
                    text > 0.11
                  

--- a/hoodle-builder/src/Text/Hoodle/Builder.hs
+++ b/hoodle-builder/src/Text/Hoodle/Builder.hs
@@ -18,7 +18,6 @@ module Text.Hoodle.Builder where
 -- from other packages 
 import           Blaze.ByteString.Builder
 import           Blaze.ByteString.Builder.Char8 (fromChar, fromString)
-import           Control.Lens 
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
 import           Data.Double.Conversion.ByteString (toFixed)
@@ -31,6 +30,7 @@ import           Data.Monoid
 import           Data.Strict.Tuple
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import           Lens.Micro.Extras (view)
 -- from hoodle platform 
 import           Data.Hoodle.Simple
 -- 

--- a/hoodle-builder/src/Text/Hoodle/Builder/V0_1_1.hs
+++ b/hoodle-builder/src/Text/Hoodle/Builder/V0_1_1.hs
@@ -15,7 +15,6 @@
 module Text.Hoodle.Builder.V0_1_1 where
 
 -- from other packages 
-import           Control.Lens 
 import qualified Data.ByteString as S
 -- import qualified Data.ByteString.Char8 as SC
 import qualified Data.ByteString.Lazy as L
@@ -28,6 +27,7 @@ import Data.Monoid hiding ((<>))
 import Data.Monoid 
 #endif 
 import Data.Strict.Tuple
+import Lens.Micro.Extras (view)
 -- from this package 
 import Data.Hoodle.Simple.V0_1_1
 

--- a/hoodle-builder/src/Text/Hoodle/Builder/V0_2_2.hs
+++ b/hoodle-builder/src/Text/Hoodle/Builder/V0_2_2.hs
@@ -18,7 +18,6 @@ module Text.Hoodle.Builder.V0_2_2 where
 -- from other packages 
 import           Blaze.ByteString.Builder
 import           Blaze.ByteString.Builder.Char8 (fromChar, fromString)
-import           Control.Lens 
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
 import           Data.Double.Conversion.ByteString (toFixed)
@@ -29,6 +28,7 @@ import           Data.Monoid hiding ((<>))
 import           Data.Monoid 
 #endif 
 import           Data.Strict.Tuple
+import           Lens.Micro.Extras (view)
 -- from hoodle platform 
 import           Data.Hoodle.Simple.V0_2_2
 -- 

--- a/hoodle-builder/src/Text/Hoodle/Builder/V0_3.hs
+++ b/hoodle-builder/src/Text/Hoodle/Builder/V0_3.hs
@@ -18,7 +18,6 @@ module Text.Hoodle.Builder.V0_3 where
 -- from other packages 
 import           Blaze.ByteString.Builder
 import           Blaze.ByteString.Builder.Char8 (fromChar, fromString)
-import           Control.Lens 
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
 import           Data.Double.Conversion.ByteString (toFixed)
@@ -31,6 +30,7 @@ import           Data.Monoid
 import           Data.Strict.Tuple
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import           Lens.Micro.Extras (view)
 -- from hoodle platform 
 import           Data.Hoodle.Simple
 -- 

--- a/hoodle-parser/hoodle-parser.cabal
+++ b/hoodle-parser/hoodle-parser.cabal
@@ -26,7 +26,7 @@ Library
                  containers >= 0.4, 
                  directory, 
                  hoodle-types >= 0.4, 
-                 lens >= 2.5, 
+                 microlens >= 0.4,
                  mtl > 2, 
                  strict >= 0.3, 
                  text >= 0.11,

--- a/hoodle-parser/hoodle-parser.cabal
+++ b/hoodle-parser/hoodle-parser.cabal
@@ -22,6 +22,7 @@ Library
   Build-Depends: base == 4.*, 
                  attoparsec >= 0.10, 
                  either >= 3.1,
+                 errors >= 2.0,
                  bytestring >= 0.9, 
                  containers >= 0.4, 
                  directory, 

--- a/hoodle-parser/hoodle-parser.cabal
+++ b/hoodle-parser/hoodle-parser.cabal
@@ -30,7 +30,7 @@ Library
                  mtl > 2, 
                  strict >= 0.3, 
                  text >= 0.11,
-                 transformers >= 0.3, 
+                 transformers >= 0.4.1,
                  xournal-types >= 0.5.1
 
   Exposed-Modules: 

--- a/hoodle-parser/src/Text/Hoodle/Migrate/FromXournal.hs
+++ b/hoodle-parser/src/Text/Hoodle/Migrate/FromXournal.hs
@@ -17,7 +17,7 @@ module Text.Hoodle.Migrate.FromXournal
 ) where
 
 import Control.Applicative
-import Control.Lens
+import Lens.Micro
 -- 
 import qualified Data.Xournal.Simple as X 
 import qualified Data.Hoodle.Simple as H

--- a/hoodle-parser/src/Text/Hoodle/Migrate/V0_1_1_to_V0_2_2.hs
+++ b/hoodle-parser/src/Text/Hoodle/Migrate/V0_1_1_to_V0_2_2.hs
@@ -18,7 +18,7 @@ module Text.Hoodle.Migrate.V0_1_1_to_V0_2_2 where
 
 import           Control.Applicative 
 import           Control.Monad.Trans
-import           Control.Monad.Trans.Either
+import           Control.Monad.Trans.Except
 import           Data.Attoparsec.ByteString
 import qualified Data.ByteString.Char8 as B
 import           Lens.Micro
@@ -93,7 +93,7 @@ layer2Layer OH.Layer {..} = NH.Layer { NH.layer_items = fmap item2Item layer_ite
 
 migrate :: B.ByteString -> IO (Either String NH.Hoodle)
 migrate bstr = do 
-  runEitherT $ do 
+  runExceptT $ do 
     v <- hoistEither (parseOnly NP.checkHoodleVersion bstr)
     if v <= "0.1.1" 
       then do  
@@ -108,3 +108,5 @@ migrate bstr = do
 {- . set NH.embeddedPdf pdf -}
 
 
+hoistEither :: Monad m => Either e a -> ExceptT e m a
+hoistEither = ExceptT . return

--- a/hoodle-parser/src/Text/Hoodle/Migrate/V0_1_1_to_V0_2_2.hs
+++ b/hoodle-parser/src/Text/Hoodle/Migrate/V0_1_1_to_V0_2_2.hs
@@ -17,11 +17,12 @@
 module Text.Hoodle.Migrate.V0_1_1_to_V0_2_2 where
 
 import           Control.Applicative 
-import           Control.Lens
 import           Control.Monad.Trans
 import           Control.Monad.Trans.Either
 import           Data.Attoparsec.ByteString
 import qualified Data.ByteString.Char8 as B
+import           Lens.Micro
+import           Lens.Micro.Extras (view)
 --
 import qualified Data.Hoodle.Simple.V0_1_1 as OH
 import qualified Data.Hoodle.Simple.V0_2_2 as NH

--- a/hoodle-parser/src/Text/Hoodle/Migrate/V0_1_1_to_V0_2_2.hs
+++ b/hoodle-parser/src/Text/Hoodle/Migrate/V0_1_1_to_V0_2_2.hs
@@ -16,7 +16,8 @@
 
 module Text.Hoodle.Migrate.V0_1_1_to_V0_2_2 where
 
-import           Control.Applicative 
+import           Control.Applicative
+import           Control.Error.Util (hoistEither)
 import           Control.Monad.Trans
 import           Control.Monad.Trans.Except
 import           Data.Attoparsec.ByteString
@@ -106,7 +107,3 @@ migrate bstr = do
 
             -- pdf = view OH.embeddedPdf oh 
 {- . set NH.embeddedPdf pdf -}
-
-
-hoistEither :: Monad m => Either e a -> ExceptT e m a
-hoistEither = ExceptT . return

--- a/hoodle-parser/src/Text/Hoodle/Migrate/V0_2_2_to_V0_3.hs
+++ b/hoodle-parser/src/Text/Hoodle/Migrate/V0_2_2_to_V0_3.hs
@@ -18,7 +18,8 @@
 
 module Text.Hoodle.Migrate.V0_2_2_to_V0_3 where
 
-import           Control.Applicative 
+import           Control.Applicative
+import           Control.Error.Util (hoistEither)
 import           Control.Monad.Trans
 import           Control.Monad.Trans.Except
 import           Data.Attoparsec.ByteString
@@ -137,7 +138,3 @@ migrate bstr = do
 
             -- pdf = view OH.embeddedPdf oh 
 {- . set NH.embeddedPdf pdf -}
-
-
-hoistEither :: Monad m => Either e a -> ExceptT e m a
-hoistEither = ExceptT . return

--- a/hoodle-parser/src/Text/Hoodle/Migrate/V0_2_2_to_V0_3.hs
+++ b/hoodle-parser/src/Text/Hoodle/Migrate/V0_2_2_to_V0_3.hs
@@ -20,7 +20,7 @@ module Text.Hoodle.Migrate.V0_2_2_to_V0_3 where
 
 import           Control.Applicative 
 import           Control.Monad.Trans
-import           Control.Monad.Trans.Either
+import           Control.Monad.Trans.Except
 import           Data.Attoparsec.ByteString
 import qualified Data.ByteString.Char8 as B
 import           Lens.Micro
@@ -123,9 +123,9 @@ hoodle2Hoodle oh =  set NH.hoodleID  (view OH.hoodleID oh)
 
 migrate :: B.ByteString -> IO (Either String NH.Hoodle)
 migrate bstr = do 
-  runEitherT $ do 
+  runExceptT $ do 
     v <- hoistEither (parseOnly NP.checkHoodleVersion bstr)
-    if | v <= "0.1.1" -> do oh <- EitherT (Text.Hoodle.Migrate.V0_1_1_to_V0_2_2.migrate bstr)
+    if | v <= "0.1.1" -> do oh <- ExceptT (Text.Hoodle.Migrate.V0_1_1_to_V0_2_2.migrate bstr)
                             let ttl = view OH.title oh 
                                 pgs = (fmap page2Page . view OH.pages) oh 
                             set NH.title ttl . set NH.pages pgs <$> lift NH.emptyHoodle 
@@ -139,3 +139,5 @@ migrate bstr = do
 {- . set NH.embeddedPdf pdf -}
 
 
+hoistEither :: Monad m => Either e a -> ExceptT e m a
+hoistEither = ExceptT . return

--- a/hoodle-parser/src/Text/Hoodle/Migrate/V0_2_2_to_V0_3.hs
+++ b/hoodle-parser/src/Text/Hoodle/Migrate/V0_2_2_to_V0_3.hs
@@ -19,11 +19,12 @@
 module Text.Hoodle.Migrate.V0_2_2_to_V0_3 where
 
 import           Control.Applicative 
-import           Control.Lens
 import           Control.Monad.Trans
 import           Control.Monad.Trans.Either
 import           Data.Attoparsec.ByteString
 import qualified Data.ByteString.Char8 as B
+import           Lens.Micro
+import           Lens.Micro.Extras (view)
 --
 import qualified Data.Hoodle.Simple.V0_2_2 as OH
 import qualified Data.Hoodle.Simple.V0_3 as NH

--- a/hoodle-parser/src/Text/Hoodle/Migrate/V0_3_to_HEAD.hs
+++ b/hoodle-parser/src/Text/Hoodle/Migrate/V0_3_to_HEAD.hs
@@ -19,7 +19,8 @@
 module Text.Hoodle.Migrate.V0_3_to_HEAD where
 
 import           Control.Applicative 
-import           Control.Lens
+import           Lens.Micro
+import           Lens.Micro.Extras (view)
 --
 import qualified Data.Hoodle.Simple.V0_3 as OH
 import qualified Data.Hoodle.Simple as NH

--- a/hoodle-types/hoodle-types.cabal
+++ b/hoodle-types/hoodle-types.cabal
@@ -25,7 +25,7 @@ Library
                    bytestring >= 0.9, 
                    containers >= 0.4, 
                    cereal > 0.3, 
-                   lens >= 2.5,
+                   microlens >= 0.4,
                    mtl > 2, 
                    strict > 0.3, 
                    text > 0.11,

--- a/hoodle-types/src/Data/Hoodle/Generic.hs
+++ b/hoodle-types/src/Data/Hoodle/Generic.hs
@@ -19,7 +19,6 @@ module Data.Hoodle.Generic where
 
 -- from other packages
 import Control.Category
-import Control.Lens 
 import Data.ByteString.Char8 hiding (map,zip)
 import Data.Foldable
 import Data.Functor
@@ -27,6 +26,7 @@ import qualified Data.IntMap as IM
 import qualified Data.Sequence as Seq 
 import qualified Data.Text as T
 import Data.UUID.V4 
+import Lens.Micro
 -- from this package
 import Data.Hoodle.Simple
 -- 
@@ -75,49 +75,49 @@ instance (Functor cntnr) => Functor (GHoodle cntnr) where
 ------------------------------
 
 -- | 
-ghoodleID :: Simple Lens (GHoodle cntnr pg) ByteString 
+ghoodleID :: Lens' (GHoodle cntnr pg) ByteString 
 ghoodleID = lens ghoodle_id (\f a -> f { ghoodle_id = a } )
 
 -- |
-gtitle :: Simple Lens (GHoodle cntnr pg) ByteString
+gtitle :: Lens' (GHoodle cntnr pg) ByteString
 gtitle = lens ghoodle_ttl (\f a -> f { ghoodle_ttl = a } )
 
 -- | 
-grevisions :: Simple Lens (GHoodle cntnr pg) [Revision]
+grevisions :: Lens' (GHoodle cntnr pg) [Revision]
 grevisions = lens ghoodle_revisions (\f a -> f { ghoodle_revisions = a } )
 
 -- | 
-gembeddedpdf :: Simple Lens (GHoodle cntnr pg) (Maybe PDFData)
+gembeddedpdf :: Lens' (GHoodle cntnr pg) (Maybe PDFData)
 gembeddedpdf = lens ghoodle_embeddedpdf (\f a -> f { ghoodle_embeddedpdf = a } )
 
 -- | 
-gembeddedtext :: Simple Lens (GHoodle cntnr pg) (Maybe T.Text)
+gembeddedtext :: Lens' (GHoodle cntnr pg) (Maybe T.Text)
 gembeddedtext = lens ghoodle_embeddedtext (\f a -> f { ghoodle_embeddedtext = a } )
 
 -- |
-gpages :: Simple Lens (GHoodle cntnr pg) (cntnr pg)
+gpages :: Lens' (GHoodle cntnr pg) (cntnr pg)
 gpages = lens ghoodle_pgs (\f a -> f { ghoodle_pgs = a } )
 
 -- |
-gdimension :: Simple Lens (GPage bkg cntnr pg) Dimension 
+gdimension :: Lens' (GPage bkg cntnr pg) Dimension 
 gdimension = lens gpage_dim (\f a -> f { gpage_dim = a } )
 
 -- |
-gbackground :: Simple Lens (GPage bkg cntnr lyr) bkg 
+gbackground :: Lens' (GPage bkg cntnr lyr) bkg 
 gbackground = lens gpage_bkg (\f a -> f { gpage_bkg = a } ) 
 
 -- |
-glayers :: Simple Lens (GPage bkg cntnr lyr) (cntnr lyr)
+glayers :: Lens' (GPage bkg cntnr lyr) (cntnr lyr)
 glayers = lens gpage_lyrs (\f a -> f { gpage_lyrs = a } ) 
 
 
 -- |
-gitems :: Simple Lens (GLayer buf cntnr itm) (cntnr itm)
+gitems :: Lens' (GLayer buf cntnr itm) (cntnr itm)
 gitems = lens glayer_itms (\f a -> f { glayer_itms = a } )
 
 
 -- |
-gbuffer :: Simple Lens (GLayer buf cntnr itm) buf 
+gbuffer :: Lens' (GLayer buf cntnr itm) buf 
 gbuffer = lens glayer_buf (\f a -> f { glayer_buf = a } )
 
 -- |

--- a/hoodle-types/src/Data/Hoodle/Hashed.hs
+++ b/hoodle-types/src/Data/Hoodle/Hashed.hs
@@ -21,12 +21,12 @@ module Data.Hoodle.Hashed where
 
 -- from other packages
 import           Control.Applicative 
-import           Control.Lens 
 import           Data.ByteString.Char8 hiding (map)
 import           Data.UUID.V4 
 import qualified Data.Serialize as SE
 import           Data.Strict.Tuple
 import qualified Data.Text as T
+import           Lens.Micro
 -- from this package
 import           Data.Hoodle.Util
 -- 
@@ -277,56 +277,56 @@ getXYtuples (VWStroke _t _c d) = map ((,)<$>fst3<*>snd3) d
 ----------------------------
 
 -- | 
-tool :: Simple Lens Stroke ByteString
+tool :: Lens' Stroke ByteString
 tool = lens stroke_tool (\f a -> f { stroke_tool = a })  
 
 -- | 
-color :: Simple Lens Stroke ByteString 
+color :: Lens' Stroke ByteString 
 color = lens stroke_color (\f a -> f { stroke_color = a } )
 
 -- |
-hoodleID :: Simple Lens Hoodle ByteString 
+hoodleID :: Lens' Hoodle ByteString 
 hoodleID = lens hoodle_id (\f a -> f { hoodle_id = a } )
 
 -- | 
-title :: Simple Lens Hoodle Title
+title :: Lens' Hoodle Title
 title = lens hoodle_title (\f a -> f { hoodle_title = a } )
 
 -- | 
-revisions :: Simple Lens Hoodle [Revision]
+revisions :: Lens' Hoodle [Revision]
 revisions = lens hoodle_revisions (\f a -> f { hoodle_revisions = a } )
 
 -- | 
-revmd5 :: Simple Lens Revision ByteString
+revmd5 :: Lens' Revision ByteString
 revmd5 = lens _revmd5 (\f a -> f { _revmd5 = a } )
 
 -- | 
-embeddedPdf :: Simple Lens Hoodle (Maybe ByteString)
+embeddedPdf :: Lens' Hoodle (Maybe ByteString)
 embeddedPdf = lens hoodle_embeddedpdf (\f a -> f { hoodle_embeddedpdf = a} )
 
 -- | 
-embeddedText :: Simple Lens Hoodle (Maybe T.Text)
+embeddedText :: Lens' Hoodle (Maybe T.Text)
 embeddedText = lens hoodle_embeddedtext (\f a -> f { hoodle_embeddedtext = a} )
 
 -- | 
-pages :: Simple Lens Hoodle [Page]
+pages :: Lens' Hoodle [Page]
 pages = lens hoodle_pages (\f a -> f { hoodle_pages = a } )
 
 
 -- | 
-dimension :: Simple Lens Page Dimension 
+dimension :: Lens' Page Dimension 
 dimension = lens page_dim (\f a -> f { page_dim = a } )
 
 -- | 
-background :: Simple Lens Page Background 
+background :: Lens' Page Background 
 background = lens page_bkg (\f a -> f { page_bkg = a } )
 
 -- | 
-layers :: Simple Lens Page [Layer] 
+layers :: Lens' Page [Layer] 
 layers = lens page_layers (\f a -> f { page_layers = a } )
 
 -- | 
-items :: Simple Lens Layer [Item]
+items :: Lens' Layer [Item]
 items = lens layer_items (\f a -> f { layer_items = a } )
 
 

--- a/hoodle-types/src/Data/Hoodle/Select.hs
+++ b/hoodle-types/src/Data/Hoodle/Select.hs
@@ -16,9 +16,10 @@ module Data.Hoodle.Select where
 
 -- from other packages
 import           Control.Applicative
-import           Control.Lens
 import           Data.ByteString
 import qualified Data.Text as T
+import           Lens.Micro
+import           Lens.Micro.Extras (view)
 --
 import           Data.Hoodle.Generic 
 import           Data.Hoodle.Simple 
@@ -33,31 +34,31 @@ data GSelect a b = GSelect { gselect_id :: ByteString
                            , gselect_selected :: b
                            }
 
-gselHoodleID :: Simple Lens (GSelect a b) ByteString 
+gselHoodleID :: Lens' (GSelect a b) ByteString 
 gselHoodleID = lens gselect_id (\f a -> f { gselect_id = a } )
 
 -- |
-gselTitle :: Simple Lens (GSelect a b) ByteString
+gselTitle :: Lens' (GSelect a b) ByteString
 gselTitle = lens gselect_ttl (\f a -> f {gselect_ttl = a})
 
 -- | 
-gselRevisions :: Simple Lens (GSelect a b) [Revision]
+gselRevisions :: Lens' (GSelect a b) [Revision]
 gselRevisions = lens gselect_revisions (\f a -> f {gselect_revisions = a } )
 
 -- |
-gselEmbeddedPdf :: Simple Lens (GSelect a b) (Maybe PDFData)
+gselEmbeddedPdf :: Lens' (GSelect a b) (Maybe PDFData)
 gselEmbeddedPdf = lens gselect_embeddedpdf (\f a -> f {gselect_embeddedpdf = a})
 
 -- |
-gselEmbeddedText :: Simple Lens (GSelect a b) (Maybe T.Text)
+gselEmbeddedText :: Lens' (GSelect a b) (Maybe T.Text)
 gselEmbeddedText = lens gselect_embeddedtext (\f a -> f {gselect_embeddedtext = a})
 
 -- |
-gselAll :: Simple Lens (GSelect a b) a 
+gselAll :: Lens' (GSelect a b) a 
 gselAll = lens gselect_all (\f a -> f {gselect_all = a} )
 
 -- |
-gselSelected :: Simple Lens (GSelect a b) b
+gselSelected :: Lens' (GSelect a b) b
 gselSelected = lens gselect_selected (\f a -> f {gselect_selected = a})
 
 

--- a/hoodle-types/src/Data/Hoodle/Simple.hs
+++ b/hoodle-types/src/Data/Hoodle/Simple.hs
@@ -24,7 +24,6 @@ module Data.Hoodle.Simple where
 
 -- from other packages
 import           Control.Applicative 
-import           Control.Lens hiding ((.=))
 import           Data.Aeson.TH
 import           Data.Aeson.Types hiding (Pair(..))
 import           Data.Char
@@ -35,6 +34,7 @@ import           Data.Strict.Tuple
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import           Data.Vector ((!),fromList)
+import           Lens.Micro
 import           Text.Printf
 -- from this package
 import           Data.Hoodle.Util
@@ -384,56 +384,56 @@ getXYtuples (VWStroke _t _c d) = map ((,)<$>fst3<*>snd3) d
 ----------------------------
 
 -- | 
-tool :: Simple Lens Stroke ByteString
+tool :: Lens' Stroke ByteString
 tool = lens stroke_tool (\f a -> f { stroke_tool = a })  
 
 -- | 
-color :: Simple Lens Stroke ByteString 
+color :: Lens' Stroke ByteString 
 color = lens stroke_color (\f a -> f { stroke_color = a } )
 
 -- |
-hoodleID :: Simple Lens Hoodle ByteString 
+hoodleID :: Lens' Hoodle ByteString 
 hoodleID = lens hoodle_id (\f a -> f { hoodle_id = a } )
 
 -- | 
-title :: Simple Lens Hoodle Title
+title :: Lens' Hoodle Title
 title = lens hoodle_title (\f a -> f { hoodle_title = a } )
 
 -- | 
-revisions :: Simple Lens Hoodle [Revision]
+revisions :: Lens' Hoodle [Revision]
 revisions = lens hoodle_revisions (\f a -> f { hoodle_revisions = a } )
 
 -- | 
-revmd5 :: Simple Lens Revision ByteString
+revmd5 :: Lens' Revision ByteString
 revmd5 = lens _revmd5 (\f a -> f { _revmd5 = a } )
 
 -- | 
-embeddedPdf :: Simple Lens Hoodle (Maybe ByteString)
+embeddedPdf :: Lens' Hoodle (Maybe ByteString)
 embeddedPdf = lens hoodle_embeddedpdf (\f a -> f { hoodle_embeddedpdf = a} )
 
 -- | 
-embeddedText :: Simple Lens Hoodle (Maybe T.Text)
+embeddedText :: Lens' Hoodle (Maybe T.Text)
 embeddedText = lens hoodle_embeddedtext (\f a -> f { hoodle_embeddedtext = a} )
 
 -- | 
-pages :: Simple Lens Hoodle [Page]
+pages :: Lens' Hoodle [Page]
 pages = lens hoodle_pages (\f a -> f { hoodle_pages = a } )
 
 
 -- | 
-dimension :: Simple Lens Page Dimension 
+dimension :: Lens' Page Dimension 
 dimension = lens page_dim (\f a -> f { page_dim = a } )
 
 -- | 
-background :: Simple Lens Page Background 
+background :: Lens' Page Background 
 background = lens page_bkg (\f a -> f { page_bkg = a } )
 
 -- | 
-layers :: Simple Lens Page [Layer] 
+layers :: Lens' Page [Layer] 
 layers = lens page_layers (\f a -> f { page_layers = a } )
 
 -- | 
-items :: Simple Lens Layer [Item]
+items :: Lens' Layer [Item]
 items = lens layer_items (\f a -> f { layer_items = a } )
 
 

--- a/hoodle-types/src/Data/Hoodle/Simple/V0_1_1.hs
+++ b/hoodle-types/src/Data/Hoodle/Simple/V0_1_1.hs
@@ -19,12 +19,12 @@ module Data.Hoodle.Simple.V0_1_1 where
 
 -- from other packages
 import           Control.Applicative 
-import           Control.Lens 
 import qualified Data.ByteString as S
 import           Data.ByteString.Char8 hiding (map)
 -- import           Data.Label
 import qualified Data.Serialize as SE
 import           Data.Strict.Tuple
+import           Lens.Micro
 -- from this package
 import           Data.Hoodle.Util
 -- 
@@ -172,35 +172,35 @@ getXYtuples (VWStroke _t _c d) = map ((,)<$>fst3<*>snd3) d
 ----------------------------
 
 -- | 
-tool :: Simple Lens Stroke ByteString
+tool :: Lens' Stroke ByteString
 tool = lens stroke_tool (\f a -> f { stroke_tool = a })  
 
 -- | 
-color :: Simple Lens Stroke ByteString 
+color :: Lens' Stroke ByteString 
 color = lens stroke_color (\f a -> f { stroke_color = a } )
 
 -- | 
-title :: Simple Lens Hoodle Title
+title :: Lens' Hoodle Title
 title = lens hoodle_title (\f a -> f { hoodle_title = a } )
 
 -- | 
-pages :: Simple Lens Hoodle [Page]
+pages :: Lens' Hoodle [Page]
 pages = lens hoodle_pages (\f a -> f { hoodle_pages = a } )
 
 -- | 
-dimension :: Simple Lens Page Dimension 
+dimension :: Lens' Page Dimension 
 dimension = lens page_dim (\f a -> f { page_dim = a } )
 
 -- | 
-background :: Simple Lens Page Background 
+background :: Lens' Page Background 
 background = lens page_bkg (\f a -> f { page_bkg = a } )
 
 -- | 
-layers :: Simple Lens Page [Layer] 
+layers :: Lens' Page [Layer] 
 layers = lens page_layers (\f a -> f { page_layers = a } )
 
 -- | 
-items :: Simple Lens Layer [Item]
+items :: Lens' Layer [Item]
 items = lens layer_items (\f a -> f { layer_items = a } )
 
 --------------------------

--- a/hoodle-types/src/Data/Hoodle/Simple/V0_2_2.hs
+++ b/hoodle-types/src/Data/Hoodle/Simple/V0_2_2.hs
@@ -17,11 +17,11 @@ module Data.Hoodle.Simple.V0_2_2 where
 
 -- from other packages
 import           Control.Applicative 
-import           Control.Lens 
 import           Data.ByteString.Char8 hiding (map)
 import           Data.UUID.V4 
 import qualified Data.Serialize as SE
 import           Data.Strict.Tuple
+import           Lens.Micro
 -- from this package
 import           Data.Hoodle.Util
 -- 
@@ -233,51 +233,51 @@ getXYtuples (VWStroke _t _c d) = map ((,)<$>fst3<*>snd3) d
 ----------------------------
 
 -- | 
-tool :: Simple Lens Stroke ByteString
+tool :: Lens' Stroke ByteString
 tool = lens stroke_tool (\f a -> f { stroke_tool = a })  
 
 -- | 
-color :: Simple Lens Stroke ByteString 
+color :: Lens' Stroke ByteString 
 color = lens stroke_color (\f a -> f { stroke_color = a } )
 
 -- |
-hoodleID :: Simple Lens Hoodle ByteString 
+hoodleID :: Lens' Hoodle ByteString 
 hoodleID = lens hoodle_id (\f a -> f { hoodle_id = a } )
 
 -- | 
-title :: Simple Lens Hoodle Title
+title :: Lens' Hoodle Title
 title = lens hoodle_title (\f a -> f { hoodle_title = a } )
 
 -- | 
-revisions :: Simple Lens Hoodle [Revision]
+revisions :: Lens' Hoodle [Revision]
 revisions = lens hoodle_revisions (\f a -> f { hoodle_revisions = a } )
 
 -- | 
-revmd5 :: Simple Lens Revision ByteString
+revmd5 :: Lens' Revision ByteString
 revmd5 = lens _revmd5 (\f a -> f { _revmd5 = a } )
 
 -- | 
-embeddedPdf :: Simple Lens Hoodle (Maybe ByteString)
+embeddedPdf :: Lens' Hoodle (Maybe ByteString)
 embeddedPdf = lens hoodle_embeddedpdf (\f a -> f { hoodle_embeddedpdf = a} )
 
 -- | 
-pages :: Simple Lens Hoodle [Page]
+pages :: Lens' Hoodle [Page]
 pages = lens hoodle_pages (\f a -> f { hoodle_pages = a } )
 
 -- | 
-dimension :: Simple Lens Page Dimension 
+dimension :: Lens' Page Dimension 
 dimension = lens page_dim (\f a -> f { page_dim = a } )
 
 -- | 
-background :: Simple Lens Page Background 
+background :: Lens' Page Background 
 background = lens page_bkg (\f a -> f { page_bkg = a } )
 
 -- | 
-layers :: Simple Lens Page [Layer] 
+layers :: Lens' Page [Layer] 
 layers = lens page_layers (\f a -> f { page_layers = a } )
 
 -- | 
-items :: Simple Lens Layer [Item]
+items :: Lens' Layer [Item]
 items = lens layer_items (\f a -> f { layer_items = a } )
 
 

--- a/hoodle-types/src/Data/Hoodle/Simple/V0_3.hs
+++ b/hoodle-types/src/Data/Hoodle/Simple/V0_3.hs
@@ -21,12 +21,12 @@ module Data.Hoodle.Simple.V0_3 where
 
 -- from other packages
 import           Control.Applicative 
-import           Control.Lens 
 import           Data.ByteString.Char8 hiding (map)
 import           Data.UUID.V4 
 import qualified Data.Serialize as SE
 import           Data.Strict.Tuple
 import qualified Data.Text as T
+import           Lens.Micro
 -- from this package
 import           Data.Hoodle.Util
 -- 
@@ -277,56 +277,56 @@ getXYtuples (VWStroke _t _c d) = map ((,)<$>fst3<*>snd3) d
 ----------------------------
 
 -- | 
-tool :: Simple Lens Stroke ByteString
+tool :: Lens' Stroke ByteString
 tool = lens stroke_tool (\f a -> f { stroke_tool = a })  
 
 -- | 
-color :: Simple Lens Stroke ByteString 
+color :: Lens' Stroke ByteString 
 color = lens stroke_color (\f a -> f { stroke_color = a } )
 
 -- |
-hoodleID :: Simple Lens Hoodle ByteString 
+hoodleID :: Lens' Hoodle ByteString 
 hoodleID = lens hoodle_id (\f a -> f { hoodle_id = a } )
 
 -- | 
-title :: Simple Lens Hoodle Title
+title :: Lens' Hoodle Title
 title = lens hoodle_title (\f a -> f { hoodle_title = a } )
 
 -- | 
-revisions :: Simple Lens Hoodle [Revision]
+revisions :: Lens' Hoodle [Revision]
 revisions = lens hoodle_revisions (\f a -> f { hoodle_revisions = a } )
 
 -- | 
-revmd5 :: Simple Lens Revision ByteString
+revmd5 :: Lens' Revision ByteString
 revmd5 = lens _revmd5 (\f a -> f { _revmd5 = a } )
 
 -- | 
-embeddedPdf :: Simple Lens Hoodle (Maybe ByteString)
+embeddedPdf :: Lens' Hoodle (Maybe ByteString)
 embeddedPdf = lens hoodle_embeddedpdf (\f a -> f { hoodle_embeddedpdf = a} )
 
 -- | 
-embeddedText :: Simple Lens Hoodle (Maybe T.Text)
+embeddedText :: Lens' Hoodle (Maybe T.Text)
 embeddedText = lens hoodle_embeddedtext (\f a -> f { hoodle_embeddedtext = a} )
 
 -- | 
-pages :: Simple Lens Hoodle [Page]
+pages :: Lens' Hoodle [Page]
 pages = lens hoodle_pages (\f a -> f { hoodle_pages = a } )
 
 
 -- | 
-dimension :: Simple Lens Page Dimension 
+dimension :: Lens' Page Dimension 
 dimension = lens page_dim (\f a -> f { page_dim = a } )
 
 -- | 
-background :: Simple Lens Page Background 
+background :: Lens' Page Background 
 background = lens page_bkg (\f a -> f { page_bkg = a } )
 
 -- | 
-layers :: Simple Lens Page [Layer] 
+layers :: Lens' Page [Layer] 
 layers = lens page_layers (\f a -> f { page_layers = a } )
 
 -- | 
-items :: Simple Lens Layer [Item]
+items :: Lens' Layer [Item]
 items = lens layer_items (\f a -> f { layer_items = a } )
 
 

--- a/xournal-parser/src/Text/Xournal/Parse/Conduit.hs
+++ b/xournal-parser/src/Text/Xournal/Parse/Conduit.hs
@@ -18,7 +18,6 @@ module Text.Xournal.Parse.Conduit where
 -- from other packages
 import           Control.Applicative 
 import           Control.Category
-import           Control.Lens
 import           Control.Monad
 import           Control.Monad.Catch
 import           Control.Monad.Trans
@@ -34,6 +33,7 @@ import qualified Data.Text as T -- hiding (foldl', zipWith)
 import           Data.Text.Encoding
 import           Data.Text.Read
 import           Data.XML.Types
+import           Lens.Micro (set)
 import           Text.XML.Stream.Render 
 import           Text.XML.Stream.Parse hiding (many)
 import           System.IO 

--- a/xournal-parser/xournal-parser.cabal
+++ b/xournal-parser/xournal-parser.cabal
@@ -32,7 +32,7 @@ Library
                  xournal-types >= 0.5.1, 
                  xml-types > 0.3, 
                  text > 0.11,
-                 lens >= 2.5, 
+                 microlens >= 0.4,
                  zlib-conduit > 0.5,
                  conduit-extra >= 1.1, 
                  exceptions >= 0.5

--- a/xournal-types/src/Data/Xournal/Generic.hs
+++ b/xournal-types/src/Data/Xournal/Generic.hs
@@ -17,10 +17,10 @@ module Data.Xournal.Generic where
 -- from other packages
 import Control.Applicative
 import Control.Category
-import Control.Lens 
 import Data.ByteString hiding (map,zip)
 import Data.Functor
 import Data.IntMap hiding (map)
+import Lens.Micro
 -- from this package
 import Data.Xournal.Simple
 -- 
@@ -144,47 +144,47 @@ instance SListable GXournal where
   chgStreamToList (GXournal t ps) = GXournal t (gToList ps)
   
 -- |
-g_title :: Simple Lens (GXournal s a) ByteString
+g_title :: Lens' (GXournal s a) ByteString
 g_title = lens gtitle (\f a -> f { gtitle = a } )
 
 -- |
-g_pages :: Simple Lens (GXournal s a) (s a)
+g_pages :: Lens' (GXournal s a) (s a)
 g_pages = lens gpages (\f a -> f { gpages = a } )
 
 -- |
-g_dimension :: Simple Lens (GPage b s a) Dimension 
+g_dimension :: Lens' (GPage b s a) Dimension 
 g_dimension = lens gdimension (\f a -> f { gdimension = a } )
 
 -- |
-g_background :: Simple Lens (GPage b s a) b 
+g_background :: Lens' (GPage b s a) b 
 g_background = lens gbackground (\f a -> f { gbackground = a } ) 
 
 -- |
-g_layers :: Simple Lens (GPage b s a) (s a)
+g_layers :: Lens' (GPage b s a) (s a)
 g_layers = lens glayers (\f a -> f { glayers = a } ) 
 
 -- |
-g_strokes :: Simple Lens (GLayer s a) (s a)
+g_strokes :: Lens' (GLayer s a) (s a)
 g_strokes = lens gstrokes (\f a -> f { gstrokes = a } )
 
 -- |
-g_bstrokes :: Simple Lens (GLayerBuf b s a) (s a)
+g_bstrokes :: Lens' (GLayerBuf b s a) (s a)
 g_bstrokes = lens gbstrokes (\f a -> f { gbstrokes = a } )
 
 -- |
-g_buffer :: Simple Lens (GLayerBuf b s a) b 
+g_buffer :: Lens' (GLayerBuf b s a) b 
 g_buffer = lens gbuffer (\f a -> f { gbuffer = a } )
 
 -- |
-g_selectTitle :: Simple Lens (GSelect a b) ByteString
+g_selectTitle :: Lens' (GSelect a b) ByteString
 g_selectTitle = lens gselectTitle (\f a -> f {gselectTitle = a})
 
 -- |
-g_selectAll :: Simple Lens (GSelect a b) a 
+g_selectAll :: Lens' (GSelect a b) a 
 g_selectAll = lens gselectAll (\f a -> f {gselectAll = a} )
 
 -- |
-g_selectSelected :: Simple Lens (GSelect a b) b
+g_selectSelected :: Lens' (GSelect a b) b
 g_selectSelected = lens gselectSelected (\f a -> f {gselectSelected = a})
 
 -- |

--- a/xournal-types/src/Data/Xournal/Simple.hs
+++ b/xournal-types/src/Data/Xournal/Simple.hs
@@ -17,11 +17,11 @@ module Data.Xournal.Simple where
 
 -- from other packages
 import           Control.Applicative 
-import           Control.Lens 
 import qualified Data.ByteString as S
 import           Data.ByteString.Char8 hiding (map)
 import qualified Data.Serialize as SE
 import           Data.Strict.Tuple
+import           Lens.Micro
 -- from this package
 import           Data.Xournal.Util
 -- 
@@ -105,35 +105,35 @@ getXYtuples (VWStroke _t _c d) = map ((,)<$>fst3<*>snd3) d
 ----------------------------
 
 -- | 
-s_tool :: Simple Lens Stroke ByteString
+s_tool :: Lens' Stroke ByteString
 s_tool = lens stroke_tool (\f a -> f { stroke_tool = a })  
 
 -- | 
-s_color :: Simple Lens Stroke ByteString 
+s_color :: Lens' Stroke ByteString 
 s_color = lens stroke_color (\f a -> f { stroke_color = a } )
 
 -- | 
-s_title :: Simple Lens Xournal Title
+s_title :: Lens' Xournal Title
 s_title = lens xoj_title (\f a -> f { xoj_title = a } )
 
 -- | 
-s_pages :: Simple Lens Xournal [Page]
+s_pages :: Lens' Xournal [Page]
 s_pages = lens xoj_pages (\f a -> f { xoj_pages = a } )
 
 -- | 
-s_dim :: Simple Lens Page Dimension 
+s_dim :: Lens' Page Dimension 
 s_dim = lens page_dim (\f a -> f { page_dim = a } )
 
 -- | 
-s_bkg :: Simple Lens Page Background 
+s_bkg :: Lens' Page Background 
 s_bkg = lens page_bkg (\f a -> f { page_bkg = a } )
 
 -- | 
-s_layers :: Simple Lens Page [Layer] 
+s_layers :: Lens' Page [Layer] 
 s_layers = lens page_layers (\f a -> f { page_layers = a } )
 
 -- | 
-s_strokes :: Simple Lens Layer [Stroke]
+s_strokes :: Lens' Layer [Stroke]
 s_strokes = lens layer_strokes (\f a -> f { layer_strokes = a } )
 
 --------------------------

--- a/xournal-types/xournal-types.cabal
+++ b/xournal-types/xournal-types.cabal
@@ -24,7 +24,7 @@ Library
                    bytestring >= 0.9, 
                    cereal > 0.3, 
                    containers >= 0.4,
-                   lens >= 2.5,
+                   microlens >= 0.4,
                    strict > 0.3, 
                    TypeCompose > 0.9 
                  


### PR DESCRIPTION
`either-4.5` deprecated `Control.Monad.Trans.Either`, and `either-5` removed it: http://hackage.haskell.org/package/either-5/changelog

This PR updates the code in `hoodle-parser` to use `Control.Monad.Trans.Except` from `transformers` instead.