### PR TITLE
Fix invalid version numbers in svgcairo

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
 resolver: lts-10.5
+allow-newer: true
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
Fixes #65 and restores builds (C dependencies notwithstanding).

I think it's actually a more pernicious issue because no version of `gtk2hs-buildtools` greater than 0.13.5.0 exists and it's asking for > 0.13.11 (due to the requirement of `gtk2hsC2hs` > 0.13.11 in svgcairo's .cabal file I think). _But_, `gtk2hs-buildtools` already provides `gtk2hsC2hs` 0.13.13. So, it's something in stack's version and/or dependency resolver. 

I don't have the expertise to debug any further, so we're left with a quickfix...