### PR TITLE
Remove strokes in buffered way

### DIFF
--- a/hoodle-ghcjs/Main.hs
+++ b/hoodle-ghcjs/Main.hs
@@ -114,7 +114,7 @@ eraserReady ev = do
     ToPenMode -> nextevent >>= penReady
     PointerDown (cx0, cy0) -> do
       HoodleState svg _ _ _ _ _ _ <- get
-      erasingMode [] (singleton (cx0, cy0))
+      erasingMode (singleton (cx0, cy0))
     _ -> pure ()
   nextevent >>= eraserReady
 
@@ -148,29 +148,51 @@ drawingMode cxys = do
       liftIO $ WS.send (JSS.pack . T.unpack . serialize $ msg) sock
     _ -> drawingMode cxys
 
-erasingMode :: [CommitId] -> Seq (Double, Double) -> MainCoroutine ()
-erasingMode hitted0 cxys = do
-  ev <- nextevent
-  case ev of
-    PointerMove cxy@(cx, cy) -> do
-      s@(HoodleState svg cvs offcvs _ (DocState _ strks) _ _) <- get
-      case viewr cxys of
-        _ :> (cx0, cy0) -> do
-          liftIO $ J.js_overlay_point cvs offcvs cx0 cy0 cx cy
-          (x0, y0) <- liftIO $ J.getXYinSVG svg (cx0, cy0)
+findHitStrokes ::
+  JSVal ->
+  Seq (Double, Double) ->
+  [(CommitId, [(Double, Double)])] ->
+  IO [CommitId]
+findHitStrokes svg cxys strks = do
+  xys_arr <-
+    J.js_to_svg_point_array svg =<< toJSValListOf (toList cxys)
+  xys <- fromJSValUncheckedListOf xys_arr
+  let pairs = zip xys (tail xys)
+      hitstrks = flip concatMap pairs $ \((x0, y0), (x, y)) ->
+        map fst $
+          filter (doesLineHitStrk ((x0, y0), (x, y)) . snd) strks
+  -- !hitted' = nub $ sort (hitted ++ hitted0)
+  pure hitstrks
+
+{-
+    (x0, y0) <- liftIO $ J.getXYinSVG svg (cx0, cy0)
           (x, y) <- liftIO $ J.getXYinSVG svg (cx, cy)
           let !hitted = map fst $ filter (doesLineHitStrk ((x0, y0), (x, y)) . snd) strks
               !hitted' = nub $ sort (hitted ++ hitted0)
-          liftIO $ traverse_ (J.strokeChangeColor svg . ("stroke" ++) . show . unCommitId) hitted
+
+-}
+
+erasingMode {- [CommitId] -> -} :: Seq (Double, Double) -> MainCoroutine ()
+erasingMode {- hitted0 -} cxys = do
+  ev <- nextevent
+  case ev of
+    PointerMove cxy@(cx, cy) -> do
+      s@(HoodleState svg cvs offcvs _ _ _ _) <- get
+      case viewr cxys of
+        _ :> (cx0, cy0) -> do
+          liftIO $ J.js_overlay_point cvs offcvs cx0 cy0 cx cy
           put $ s {_hdlstateOverlayUpdated = True}
-          erasingMode hitted' (cxys |> cxy)
+          erasingMode (cxys |> cxy)
         _ -> pure ()
     PointerUp _ -> do
-      HoodleState svg _ _ sock _ _ _ <- get
-      when (not . null $ hitted0) $ liftIO $ do
-        let msg = DeleteStrokes hitted0
+      HoodleState svg _ _ sock (DocState _ strks) _ _ <- get
+      hstrks <- liftIO $ findHitStrokes svg cxys strks
+      liftIO $
+        traverse_ (J.strokeChangeColor svg . ("stroke" ++) . show . unCommitId) hstrks
+      when (not . null $ hstrks) $ liftIO $ do
+        let msg = DeleteStrokes hstrks
         WS.send (JSS.pack . T.unpack . serialize $ msg) sock
-    _ -> erasingMode hitted0 cxys
+    _ -> erasingMode cxys
 
 initmc :: MainObj ()
 initmc = ReaderT $ (\(Arg DoEvent ev) -> guiProcess ev)


### PR DESCRIPTION
To reduce computation, hit tests for strokes are done only every 10 move events.