### PR TITLE
Plugin that finds implicitly imported names automatically  

### DIFF
--- a/build-tools/hoodle-build-tools.cabal
+++ b/build-tools/hoodle-build-tools.cabal
@@ -21,6 +21,13 @@ maintainer:         ianwookim@gmail.com
 -- category:
 extra-source-files: CHANGELOG.md
 
+library
+  hs-source-dirs:     src
+  Build-Depends:      base == 4.*,
+                      ghc == 8.8.*
+  Exposed-Modules:
+                      Plugin.CheckImports
+
 executable checkImports
     main-is:          checkImports.hs
 

--- a/build-tools/hoodle-build-tools.cabal
+++ b/build-tools/hoodle-build-tools.cabal
@@ -24,6 +24,7 @@ extra-source-files: CHANGELOG.md
 library
   hs-source-dirs:     src
   Build-Depends:      base == 4.*,
+                      containers,
                       ghc == 8.8.*,
                       transformers
   Exposed-Modules:

--- a/build-tools/hoodle-build-tools.cabal
+++ b/build-tools/hoodle-build-tools.cabal
@@ -24,7 +24,8 @@ extra-source-files: CHANGELOG.md
 library
   hs-source-dirs:     src
   Build-Depends:      base == 4.*,
-                      ghc == 8.8.*
+                      ghc == 8.8.*,
+                      transformers
   Exposed-Modules:
                       Plugin.CheckImports
 

--- a/build-tools/src/Plugin/CheckImports.hs
+++ b/build-tools/src/Plugin/CheckImports.hs
@@ -1,21 +1,120 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Plugin.CheckImports (plugin) where
 
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import CoreMonad
+  ( getDynFlags,
+    getHscEnv,
+    getModule,
+    getOrigNameCache,
+  )
+import Data.Foldable (for_)
+import Data.IORef (readIORef)
+import DynFlags (DynFlags)
+import GHC (getModuleInfo)
 import GhcPlugins
   ( CommandLineOption,
     CoreM,
     CoreToDo,
+    HsParsedModule,
+    Hsc,
+    ModSummary,
     Plugin (..),
     defaultPlugin,
     putMsgS,
   )
+import HsDecls (HsGroup (..))
+import HsExtension (GhcRn)
+import HscTypes (HsParsedModule (..), ModIface (..))
+import Module (lookupModuleEnv)
+import Outputable (Outputable (ppr), showSDoc)
+import RdrName
+  ( GlobalRdrElt (..),
+    GlobalRdrEnv,
+    greLabel,
+    pprGlobalRdrEnv,
+    pprNameProvenance,
+  )
+import TcRnTypes (IfM, TcGblEnv (..), TcM)
 
 plugin :: Plugin
 plugin =
   defaultPlugin
-    { installCoreToDos = install
+    { parsedResultAction = parsedPlugin,
+      renamedResultAction = renamedAction,
+      typeCheckResultAction = typecheckPlugin,
+      interfaceLoadAction = interfaceLoadPlugin
+      -- installCoreToDos = install
     }
 
-install :: [CommandLineOption] -> [CoreToDo] -> CoreM [CoreToDo]
-install _ todo = do
-  putMsgS "Hello!"
+printPpr :: (Outputable a, MonadIO m) => DynFlags -> a -> m ()
+printPpr dflags = liftIO . putStrLn . showSDoc dflags . ppr
+
+parsedPlugin ::
+  [CommandLineOption] ->
+  ModSummary ->
+  HsParsedModule ->
+  Hsc HsParsedModule
+parsedPlugin _ _ mod = do
+  liftIO $ putStrLn "my TEst"
+  dflags <- getDynFlags
+  printPpr dflags (hpm_module mod)
+  pure mod
+
+renamedAction ::
+  [CommandLineOption] ->
+  TcGblEnv ->
+  HsGroup GhcRn ->
+  TcM (TcGblEnv, HsGroup GhcRn)
+renamedAction _ env grp = do
+  liftIO $ putStrLn "renamed action invoked"
+  dflags <- getDynFlags
+  printPpr dflags grp
+  printPpr dflags (hs_valds grp)
+  pure (env, grp)
+
+interfaceLoadPlugin ::
+  [CommandLineOption] ->
+  ModIface ->
+  IfM lcl ModIface
+interfaceLoadPlugin _ iface = do
+  dflags <- getDynFlags
+  liftIO $ putStrLn "interface loaded"
+  printPpr dflags (mi_module iface)
+  return iface
+
+typecheckPlugin ::
+  [CommandLineOption] ->
+  ModSummary ->
+  TcGblEnv ->
+  TcM TcGblEnv
+typecheckPlugin _ modsummary tc = do
+  liftIO $ putStrLn "typecheck plugin"
+  dflags <- getDynFlags
+  let globalRdrEnv :: GlobalRdrEnv
+      globalRdrEnv = tcg_rdr_env tc
+
+  usedGREs :: [GlobalRdrElt] <-
+    liftIO $ readIORef (tcg_used_gres tc)
+  for_ usedGREs $ \gre -> liftIO $ do
+    printPpr dflags (gre_name gre)
+    putStrLn $ showSDoc dflags $ pprNameProvenance gre
+  printPpr dflags modsummary
+  pure tc
+
+{-  env <- getHscEnv
+  dflags <- getDynFlags
+  let printPpr :: (Outputable a) => a -> CoreM ()
+      printPpr = putMsgS . showSDoc dflags . ppr
+  modu <- getModule
+  printPpr modu
+  nameCache <- getOrigNameCache
+  let moccEnv = lookupModuleEnv nameCache modu
+  case moccEnv of
+    Nothing -> putMsgS "Nothing"
+    Just occEnv -> printPpr occEnv
+  -- moduInfo <- getModuleInfo modu
+  -- printPpr moduInfo
   pure todo
+-}

--- a/build-tools/src/Plugin/CheckImports.hs
+++ b/build-tools/src/Plugin/CheckImports.hs
@@ -1,0 +1,21 @@
+module Plugin.CheckImports (plugin) where
+
+import GhcPlugins
+  ( CommandLineOption,
+    CoreM,
+    CoreToDo,
+    Plugin (..),
+    defaultPlugin,
+    putMsgS,
+  )
+
+plugin :: Plugin
+plugin =
+  defaultPlugin
+    { installCoreToDos = install
+    }
+
+install :: [CommandLineOption] -> [CoreToDo] -> CoreM [CoreToDo]
+install _ todo = do
+  putMsgS "Hello!"
+  pure todo


### PR DESCRIPTION
Using GHC source plugin, we can find all the imported symbols in the module, so that we can ease the task of cleaning up unqualified imports.