### PR TITLE
Live eventlog monitoring through a socket

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,3 +10,4 @@ packages:
   ./publish/hoodle-publish.cabal
   ./core/hoodle-core.cabal
   ./hoodle/hoodle.cabal
+  ./log/hoodle-log.cabal

--- a/cabal.project.local.ghcHEAD
+++ b/cabal.project.local.ghcHEAD
@@ -15,7 +15,7 @@ source-repository-package
 source-repository-package
         type: git
         location: https://github.com/wavewave/ghc-eventlog-socket.git
-        tag: c8098d25e0218f98316aaaa9b93cffea81eeed96
+        tag: ef3ac4b6c65f493ce1549d9f842e7a434a9db4a2
 
 source-repository-package
         type: git

--- a/core/src/Hoodle/GUI.hs
+++ b/core/src/Hoodle/GUI.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -106,7 +107,7 @@ startGUI mfname mhook = do
 
 clock :: (AllEvent -> IO ()) -> IO ()
 clock evhandler = forever $ do
-  threadDelay 1000000
+  threadDelay 1_000_000
   Gtk.postGUIAsync (evhandler (SysEv ClockUpdateEvent))
 
 outerLayout :: Gtk.UIManager -> Gtk.VBox -> HoodleState -> IO ()

--- a/core/src/Hoodle/Type/Coroutine.hs
+++ b/core/src/Hoodle/Type/Coroutine.hs
@@ -99,7 +99,7 @@ world xstate initmc = ReaderT staction
       go mcobj req
 
 -- |
-type Driver a = D.Driver AllEvent IO a -- SObjT MainOp IO a
+type Driver a = D.Driver AllEvent IO a
 
 -- |
 type DriverB = SObjBT (D.DrvOp AllEvent) IO

--- a/coroutine-object/src/Control/Monad/Trans/Crtn/EventHandler.hs
+++ b/coroutine-object/src/Control/Monad/Trans/Crtn/EventHandler.hs
@@ -11,9 +11,12 @@ import Control.Monad.Trans.Crtn.Event (ActionOrder (..))
 import Control.Monad.Trans.Crtn.Logger (scribe)
 import Control.Monad.Trans.Except (runExceptT)
 
+import Debug.Trace (traceEventIO)
+
 -- |
 eventHandler :: MVar (Maybe (Driver e IO ())) -> e -> IO ()
 eventHandler evar ev = do
+  traceEventIO "eventHandler is called"
   mnext <- takeMVar evar
   case mnext of
     Nothing -> return ()

--- a/coroutine-object/src/Control/Monad/Trans/Crtn/EventHandler.hs
+++ b/coroutine-object/src/Control/Monad/Trans/Crtn/EventHandler.hs
@@ -11,12 +11,9 @@ import Control.Monad.Trans.Crtn.Event (ActionOrder (..))
 import Control.Monad.Trans.Crtn.Logger (scribe)
 import Control.Monad.Trans.Except (runExceptT)
 
-import Debug.Trace (traceEventIO)
-
 -- |
 eventHandler :: MVar (Maybe (Driver e IO ())) -> e -> IO ()
 eventHandler evar ev = do
-  traceEventIO "eventHandler is called"
   mnext <- takeMVar evar
   case mnext of
     Nothing -> return ()

--- a/flake.lock
+++ b/flake.lock
@@ -35,16 +35,40 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghc-eventlog-socket": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1676068536,
+        "narHash": "sha256-hBO8gBR7uuc5NpZc25zN2KWMyRrgdAKImT/xCSGRj88=",
+        "owner": "wavewave",
+        "repo": "ghc-eventlog-socket",
+        "rev": "c8098d25e0218f98316aaaa9b93cffea81eeed96",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "flake",
+        "repo": "ghc-eventlog-socket",
         "type": "github"
       }
     },
@@ -73,28 +97,6 @@
         "owner": "wavewave",
         "ref": "fix-hash-again",
         "repo": "ghc.nix",
-        "type": "github"
-      }
-    },        
-    "ghc-eventlog-socket": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1675384778,
-        "narHash": "sha256-TAdC3jUajMZx3KeSYfBt0733Slfhap98zsvu7iPtgMI=",
-        "owner": "wavewave",
-        "repo": "ghc-eventlog-socket",
-        "rev": "8c686a4de8f41f8d6432e13766c7431fb632e8b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "wavewave",        
-        "ref": "flake",
-        "repo": "ghc-eventlog-socket",
         "type": "github"
       }
     },
@@ -146,9 +148,9 @@
       "inputs": {
         "TypeCompose": "TypeCompose",
         "flake-utils": "flake-utils",
+        "ghc-eventlog-socket": "ghc-eventlog-socket",
         "ghc_nix": "ghc_nix",
         "hackage-index": "hackage-index",
-        "ghc-eventlog-socket": "ghc-eventlog-socket",
         "nixpkgs": "nixpkgs",
         "nixpkgs_21_11": "nixpkgs_21_11"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -58,16 +58,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1676068536,
-        "narHash": "sha256-hBO8gBR7uuc5NpZc25zN2KWMyRrgdAKImT/xCSGRj88=",
+        "lastModified": 1677032363,
+        "narHash": "sha256-4DrlcJkYKlNkmyAhH45DI3E/mRy2GDQosLskISPqsB0=",
         "owner": "wavewave",
         "repo": "ghc-eventlog-socket",
-        "rev": "c8098d25e0218f98316aaaa9b93cffea81eeed96",
+        "rev": "ef3ac4b6c65f493ce1549d9f842e7a434a9db4a2",
         "type": "github"
       },
       "original": {
         "owner": "wavewave",
-        "ref": "flake",
+        "ref": "darwin-flake",
         "repo": "ghc-eventlog-socket",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -75,6 +75,28 @@
         "repo": "ghc.nix",
         "type": "github"
       }
+    },        
+    "ghc-eventlog-socket": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1675384778,
+        "narHash": "sha256-TAdC3jUajMZx3KeSYfBt0733Slfhap98zsvu7iPtgMI=",
+        "owner": "wavewave",
+        "repo": "ghc-eventlog-socket",
+        "rev": "8c686a4de8f41f8d6432e13766c7431fb632e8b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",        
+        "ref": "flake",
+        "repo": "ghc-eventlog-socket",
+        "type": "github"
+      }
     },
     "hackage-index": {
       "flake": false,
@@ -126,6 +148,7 @@
         "flake-utils": "flake-utils",
         "ghc_nix": "ghc_nix",
         "hackage-index": "hackage-index",
+        "ghc-eventlog-socket": "ghc-eventlog-socket",
         "nixpkgs": "nixpkgs",
         "nixpkgs_21_11": "nixpkgs_21_11"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
     ghc-eventlog-socket = {
       url = "github:wavewave/ghc-eventlog-socket/flake";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
     };
   };
   outputs = inputs @ {

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,10 @@
       inputs.nixpkgs-unstable.follows = "nixpkgs";
       inputs.all-cabal-hashes.follows = "hackage-index";
     };
+    ghc-eventlog-socket = {
+      url = "github:wavewave/ghc-eventlog-socket/flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
   outputs = inputs @ {
     self,
@@ -42,6 +46,8 @@
 
       haskellOverlay = hself: hsuper:
         {
+          "eventlog-socket" =
+            hself.callCabal2nix "eventlog-socket" inputs.ghc-eventlog-socket { };
           "TypeCompose" =
             hself.callCabal2nix "TypeCompose" inputs.TypeCompose {};
         }

--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,8 @@
             pkgs.gnome.adwaita-icon-theme
             pkgs.pkg-config
             pkgs.haskell.packages.${compiler}.cabal-install
+            pkgs.haskell.packages.${compiler}.haskell-language-server
+            pkgs.haskell.packages.${compiler}.implicit-hie            
           ];
           shellHook = ''
             export XDG_DATA_DIRS=${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}:$XDG_ICON_DIRS:$XDG_DATA_DIRS

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
       inputs.all-cabal-hashes.follows = "hackage-index";
     };
     ghc-eventlog-socket = {
-      url = "github:wavewave/ghc-eventlog-socket/flake";
+      url = "github:wavewave/ghc-eventlog-socket/darwin-flake";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,64 @@
+cradle:
+  cabal:
+    - path: "./builder/src"
+      component: "lib:hoodle-builder"
+
+    - path: "./core/src"
+      component: "lib:hoodle-core"
+
+    - path: "./coroutine-object/src"
+      component: "lib:coroutine-object"
+
+    - path: "./coroutine-object/example/coroutine-object-test.hs"
+      component: "coroutine-object:exe:coroutine-object-test"
+
+    - path: "./coroutine-object/example/Event.hs"
+      component: "coroutine-object:exe:coroutine-object-test"
+
+    - path: "./coroutine-object/example/Sample.hs"
+      component: "coroutine-object:exe:coroutine-object-test"
+
+    - path: "./coroutine-object/example/SampleActor.hs"
+      component: "coroutine-object:exe:coroutine-object-test"
+
+    - path: "./coroutine-object/example/Simple.hs"
+      component: "coroutine-object:exe:coroutine-object-test"
+
+    - path: "./hoodle/app/hoodle/Main.hs"
+      component: "hoodle:exe:hoodle"
+
+    - path: "./hoodle/src"
+      component: "lib:hoodle"
+
+    - path: "./log/app/logcat/Main.hs"
+      component: "hoodle-log:exe:logcat"
+
+    - path: "./parser/src"
+      component: "lib:hoodle-parser"
+
+    - path: "./parser/examples/parsetest.hs"
+      component: "hoodle-parser:exe:parsetest"
+
+    - path: "./publish/src"
+      component: "lib:hoodle-publish"
+
+    - path: "./publish/app/hoodle-publish/Main.hs"
+      component: "hoodle-publish:exe:hoodle-publish"
+
+    - path: "./publish/app/print1page/Main.hs"
+      component: "hoodle-publish:exe:print1page"
+
+    - path: "./render/src"
+      component: "lib:hoodle-render"
+
+    - path: "./types/src"
+      component: "lib:hoodle-types"
+
+    - path: "./util/src"
+      component: "lib:hoodle-util"
+
+    - path: "./xournal-parser/src"
+      component: "lib:xournal-parser"
+
+    - path: "./xournal-types/src"
+      component: "lib:xournal-types"

--- a/hie.yaml
+++ b/hie.yaml
@@ -33,6 +33,9 @@ cradle:
     - path: "./log/app/logcat/Main.hs"
       component: "hoodle-log:exe:logcat"
 
+    - path: "./log/app/testApp/Main.hs"
+      component: "hoodle-log:exe:testApp"
+
     - path: "./parser/src"
       component: "lib:hoodle-parser"
 

--- a/hoodle/app/hoodle/Main.hs
+++ b/hoodle/app/hoodle/Main.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -w #-}
+{-# LANGUAGE NumericUnderscores #-}
 
 -- |
 -- Module      : Main
@@ -12,7 +13,8 @@ module Main where
 
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Monad (forever)
-import GHC.Eventlog.Socket (flush, startWait)
+import Debug.Trace (flushEventLog)
+import GHC.Eventlog.Socket (startWait)
 import Hoodle.Script (defaultScriptConfig)
 import Hoodle.StartUp (hoodleStartMain)
 
@@ -21,5 +23,6 @@ main = do
   startWait "/tmp/eventlog.sock"
   forkIO $
     forever $ do
-      threadDelay 1000000
+      threadDelay 5_000_000
+      flushEventLog
   hoodleStartMain defaultScriptConfig

--- a/hoodle/app/hoodle/Main.hs
+++ b/hoodle/app/hoodle/Main.hs
@@ -1,13 +1,14 @@
-{-# OPTIONS_GHC -w #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NumericUnderscores #-}
 
 module Main where
 
+#ifdef USE_EVENTLOG
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Monad (forever)
 import Debug.Trace (flushEventLog)
 import GHC.Eventlog.Socket (startWait)
+#endif
 import Hoodle.Script (defaultScriptConfig)
 import Hoodle.StartUp (hoodleStartMain)
 
@@ -15,7 +16,7 @@ main :: IO ()
 main = do
 #ifdef USE_EVENTLOG
   startWait "/tmp/eventlog.sock"
-  forkIO $
+  _ <- forkIO $
     forever $ do
       threadDelay 5_000_000
       flushEventLog

--- a/hoodle/app/hoodle/Main.hs
+++ b/hoodle/app/hoodle/Main.hs
@@ -1,14 +1,7 @@
 {-# OPTIONS_GHC -w #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NumericUnderscores #-}
 
--- |
--- Module      : Main
--- Copyright   : (c) 2011-2013 Ian-Woo Kim
---
--- License     : GPL-3
--- Maintainer  : Ian-Woo Kim <ianwookim@gmail.com>
--- Stability   : experimental
--- Portability : GHC
 module Main where
 
 import Control.Concurrent (forkIO, threadDelay)
@@ -20,9 +13,11 @@ import Hoodle.StartUp (hoodleStartMain)
 
 main :: IO ()
 main = do
+#ifdef USE_EVENTLOG
   startWait "/tmp/eventlog.sock"
   forkIO $
     forever $ do
       threadDelay 5_000_000
       flushEventLog
+#endif
   hoodleStartMain defaultScriptConfig

--- a/hoodle/app/hoodle/Main.hs
+++ b/hoodle/app/hoodle/Main.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -w #-}
+
 -- |
 -- Module      : Main
 -- Copyright   : (c) 2011-2013 Ian-Woo Kim
@@ -8,8 +10,16 @@
 -- Portability : GHC
 module Main where
 
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Monad (forever)
+import GHC.Eventlog.Socket (flush, startWait)
 import Hoodle.Script (defaultScriptConfig)
 import Hoodle.StartUp (hoodleStartMain)
 
 main :: IO ()
-main = hoodleStartMain defaultScriptConfig
+main = do
+  startWait "/tmp/eventlog.sock"
+  forkIO $
+    forever $ do
+      threadDelay 1000000
+  hoodleStartMain defaultScriptConfig

--- a/hoodle/hoodle.cabal
+++ b/hoodle/hoodle.cabal
@@ -23,6 +23,8 @@ Executable hoodle
     ghc-options: -Wall -Werror -threaded -rtsopts
   else
     ghc-options: -Wall -Werror -threaded -rtsopts -eventlog
+  if flag(eventlog)
+    cpp-options: -DUSE_EVENTLOG
   ghc-prof-options: -fprof-auto -fprof-cafs
   Build-Depends:
                  base == 4.*,
@@ -52,3 +54,8 @@ Library
                    Hoodle.StartUp
   Other-Modules:
                    Paths_hoodle
+
+Flag eventlog
+    Description: eventlog socket communication
+    Manual: True
+    Default: False

--- a/hoodle/hoodle.cabal
+++ b/hoodle/hoodle.cabal
@@ -17,13 +17,17 @@ Source-repository head
   location: http://www.github.com/wavewave/hoodle
 
 Executable hoodle
-  Main-is: Main.hs
+  Main-is:        Main.hs
   hs-source-dirs: app/hoodle
-  ghc-options: 	-Wall -Werror -threaded -rtsopts
+  if impl (ghc > 9.4.0)
+    ghc-options: -Wall -Werror -threaded -rtsopts
+  else
+    ghc-options: -Wall -Werror -threaded -rtsopts -eventlog
   ghc-prof-options: -fprof-auto -fprof-cafs
   Build-Depends:
                  base == 4.*,
                  cmdargs >= 0.7,
+                 eventlog-socket,
                  hoodle-core,
                  hoodle
 

--- a/hoodle/src/Hoodle/ProgType.hs
+++ b/hoodle/src/Hoodle/ProgType.hs
@@ -31,6 +31,7 @@ import System.Console.CmdArgs
     (&=),
   )
 
+-- TODO: rename xojfile and Test. use optparse-applicative.
 data Hoodle = Test
   { xojfile :: Maybe FilePath
   }

--- a/log/app/logcat/Main.hs
+++ b/log/app/logcat/Main.hs
@@ -11,6 +11,7 @@ import qualified Data.ByteString.Lazy as BL
 import Data.List (group, sort)
 import Data.Maybe (fromMaybe, mapMaybe)
 import GHC.Generics
+import GHC.RTS.Events (Event (..), EventInfo (..))
 import GHC.RTS.Events.Incremental
   ( Decoder (..),
     decodeEvents,
@@ -30,12 +31,11 @@ import Network.Socket
 import Network.Socket.ByteString (recv)
 import System.IO (hFlush, stdout)
 import Text.Pretty.Simple (pPrint)
-import GHC.RTS.Events (Event (..), EventInfo (..))
 
 histo :: [String] -> [(String, Int)]
 histo = mapMaybe count . group . sort
   where
-    count ys@(x:xs) = Just (x, length ys)
+    count ys@(x : xs) = Just (x, length ys)
     count [] = Nothing
 
 eventInfoToString :: EventInfo -> String

--- a/log/app/logcat/Main.hs
+++ b/log/app/logcat/Main.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -w #-}
+
+module Main where
+
+import qualified Control.Exception as E
+import Control.Monad (forever)
+import qualified Data.ByteString.Lazy as BL
+import GHC.RTS.Events.Incremental (readEvents, readHeader)
+import Network.Socket
+  ( Family (AF_UNIX),
+    SockAddr (SockAddrUnix),
+    Socket,
+    SocketType (Stream),
+    close,
+    connect,
+    socket,
+    withSocketsDo,
+  )
+import Network.Socket.ByteString (recv)
+import Text.Pretty.Simple (pPrint)
+
+dump :: Socket -> IO ()
+dump sock = goHeader ""
+  where
+    goHeader bs0 = do
+      bs1 <- recv sock 1024
+      let bs = bs0 <> bs1
+      let lbs = BL.fromStrict bs
+      let e = readHeader lbs
+      case e of
+        Left err -> print err >> goHeader bs
+        Right (hdr, lbs') -> pPrint hdr >> goEvents hdr (BL.toStrict lbs')
+
+    goEvents hdr bs0 = do
+      bs1 <- recv sock 100000000
+      let bs = bs0 <> bs1
+      let lbs = BL.fromStrict bs
+      let (evs, merr) = readEvents hdr lbs
+      mapM_ pPrint evs
+      print merr
+      goEvents hdr ""
+
+main :: IO ()
+main = do
+  withSocketsDo $ do
+    let file = "/tmp/eventlog.sock"
+        open = do
+          sock <- socket AF_UNIX Stream 0
+          connect sock (SockAddrUnix file)
+          pure sock
+    E.bracket open close dump
+    pure ()

--- a/log/app/logcat/Main.hs
+++ b/log/app/logcat/Main.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -w #-}
 
 module Main where

--- a/log/app/logcat/Main.hs
+++ b/log/app/logcat/Main.hs
@@ -1,11 +1,17 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -w #-}
 
 module Main where
 
 import qualified Control.Exception as E
 import Control.Monad (forever)
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
+import Data.List (group, sort)
+import Data.Maybe (mapMaybe)
+import GHC.Generics
 import GHC.RTS.Events.Incremental (readEvents, readHeader)
 import Network.Socket
   ( Family (AF_UNIX),
@@ -19,6 +25,124 @@ import Network.Socket
   )
 import Network.Socket.ByteString (recv)
 import Text.Pretty.Simple (pPrint)
+import GHC.RTS.Events (Event (..), EventInfo (..))
+
+histo :: [String] -> [(String, Int)]
+histo = mapMaybe count . group . sort
+  where
+    count ys@(x:xs) = Just (x, length ys)
+    count [] = Nothing
+
+eventInfoToString :: EventInfo -> String
+eventInfoToString info =
+  case info of
+    EventBlock {} -> "EventBlock"
+    UnknownEvent {} -> "UnknownEvent"
+    Startup {} -> "Startup"
+    Shutdown {} -> "Shutdown"
+    CreateThread {} -> "CreateThread"
+    RunThread {} -> "RunThread"
+    StopThread {} -> "StopThread"
+    ThreadRunnable {} -> "ThreadRunnable"
+    MigrateThread {} -> "MigrateThread"
+    WakeupThread {} -> "WakeupThread"
+    ThreadLabel {} -> "ThreadLabel"
+    CreateSparkThread {} -> "CreateSparkThread"
+    SparkCounters {} -> "SparkCounters"
+    SparkCreate {} -> "SparkCreate"
+    SparkDud {} -> "SparkDud"
+    SparkOverflow {} -> "SparkOverflow"
+    SparkRun {} -> "SparkRun"
+    SparkSteal {} -> "SparkSteal"
+    SparkFizzle {} -> "SparkFizzle"
+    SparkGC {} -> "SparkGC"
+    TaskCreate {} -> "TaskCreate"
+    TaskMigrate {} -> "TaskMigrate"
+    TaskDelete {} -> "TaskDelete"
+    RequestSeqGC {} -> "RequestSeqGC"
+    RequestParGC {} -> "RequestParGC"
+    StartGC {} -> "StartGC"
+    GCWork {} -> "GCWork"
+    GCIdle {} -> "GCIdle"
+    GCDone {} -> "GCDone"
+    EndGC {} -> "EndGC"
+    GlobalSyncGC {} -> "GlobalSyncGC"
+    GCStatsGHC {} -> "GCStatsGHC"
+    MemReturn {} -> "MemReturn"
+    HeapAllocated {} -> "HeapAllocated"
+    HeapSize {} -> "HeapSize"
+    BlocksSize {} -> "BlocksSize"
+    HeapLive {} -> "HeapLive"
+    HeapInfoGHC {} -> "HeapInfoGHC"
+    CapCreate {} -> "CapCreate"
+    CapDelete {} -> "CapDelete"
+    CapDisable {} -> "CapDisable"
+    CapEnable {} -> "CapEnable"
+    CapsetCreate {} -> "CapsetCreate"
+    CapsetDelete {} -> "CapsetDelete"
+    CapsetAssignCap {} -> "CapsetAssignCap"
+    CapsetRemoveCap {} -> "CapsetRemoveCap"
+    RtsIdentifier {} -> "RtsIdentifier"
+    ProgramArgs {} -> "ProgramArgs"
+    ProgramEnv {} -> "ProgramEnv"
+    OsProcessPid {} -> "OsProcessPid"
+    OsProcessParentPid {} -> "OsProcessParentPid"
+    WallClockTime {} -> "WallClockTime"
+    Message {} -> "Message"
+    UserMessage {} -> "UserMessage"
+    UserMarker {} -> "UserMarker"
+    Version {} -> "Version"
+    ProgramInvocation {} -> "ProgramInvocation"
+    CreateMachine {} -> "CreateMachine"
+    KillMachine {} -> "KillMachine"
+    CreateProcess {} -> "CreateProcess"
+    KillProcess {} -> "KillProcess"
+    AssignThreadToProcess {} -> "AssignThreadToProcess"
+    EdenStartReceive {} -> "EdenStartReceive"
+    EdenEndReceive {} -> "EdenEndReceive"
+    SendMessage {} -> "SendMessage"
+    ReceiveMessage {} -> "ReceiveMessage"
+    SendReceiveLocalMessage {} -> "SendReceiveLocalMessage"
+    InternString {} -> "InternString"
+    MerStartParConjunction {} -> "MerStartParConjunction"
+    MerEndParConjunction {} -> "MerEndParConjunction"
+    MerEndParConjunct {} -> "MerEndParConjunct"
+    MerCreateSpark {} -> "MerCreateSpark"
+    MerFutureCreate {} -> "MerFutureCreate"
+    MerFutureWaitNosuspend {} -> "MerFutureWaitNosuspend"
+    MerFutureWaitSuspended {} -> "MerFutureWaitSuspended"
+    MerFutureSignal {} -> "MerFutureSignal"
+    MerLookingForGlobalThread {} -> "MerLookingForGlobalThread"
+    MerWorkStealing {} -> "MerWorkStealing"
+    MerLookingForLocalSpark {} -> "MerLookingForLocalSpark"
+    MerReleaseThread {} -> "MerReleaseThread"
+    MerCapSleeping {} -> "MerCapSleeping"
+    MerCallingMain {} -> "MerCallingMain"
+    PerfName {} -> "PerfName"
+    PerfCounter {} -> "PerfCounter"
+    PerfTracepoint {} -> "PerfTracepoint"
+    HeapProfBegin {} -> "HeapProfBegin"
+    HeapProfCostCentre {} -> "HeapProfCostCentre"
+    InfoTableProv {} -> "InfoTableProv"
+    HeapProfSampleBegin {} -> "HeapProfSampleBegin"
+    HeapProfSampleEnd {} -> "HeapProfSampleEnd"
+    HeapBioProfSampleBegin {} -> "HeapBioProfSampleBegin"
+    HeapProfSampleCostCentre {} -> "HeapBioProfSampleCostCentre"
+    HeapProfSampleString {} -> "HeapProfSampleString"
+    ProfSampleCostCentre {} -> "ProfSampleCostCentre"
+    ProfBegin {} -> "ProfBegin"
+    UserBinaryMessage {} -> "UserBinaryMessage"
+    ConcMarkBegin {} -> "ConcMarkBegin"
+    ConcMarkEnd {} -> "ConcMarkEnd"
+    ConcSyncBegin {} -> "ConcSyncBegin"
+    ConcSyncEnd {} -> "ConcSyncEnd"
+    ConcSweepBegin {} -> "ConcSweepBegin"
+    ConcSweepEnd {} -> "ConcSweepEnd"
+    ConcUpdRemSetFlush {} -> "ConcUpdRemSetFlush"
+    NonmovingHeapCensus {} -> "NonmovingHeapCensus"
+    TickyCounterDef {} -> "TickyCounterDef"
+    TickyCounterSample {} -> "TickyCounterSample"
+    TickyBeginSample {} -> "TickyBeginSample"
 
 dump :: Socket -> IO ()
 dump sock = goHeader ""
@@ -35,9 +159,12 @@ dump sock = goHeader ""
     goEvents hdr bs0 = do
       bs1 <- recv sock 100000000
       let bs = bs0 <> bs1
+      print (BS.length bs)
       let lbs = BL.fromStrict bs
       let (evs, merr) = readEvents hdr lbs
-      mapM_ pPrint evs
+      putStrLn $ "number of events: " <> show (length evs)
+      print (histo $ fmap (eventInfoToString . evSpec) evs)
+      -- mapM_ pPrint evs
       print merr
       goEvents hdr ""
 

--- a/log/app/logcat/Main.hs
+++ b/log/app/logcat/Main.hs
@@ -159,7 +159,7 @@ dump sock = goHeader ""
     goEvents hdr bs0 = do
       bs1 <- recv sock 100000000
       let bs = bs0 <> bs1
-      print (BS.length bs)
+      putStrLn $ "bytes: " <> show (BS.length bs)
       let lbs = BL.fromStrict bs
       let (evs, merr) = readEvents hdr lbs
       putStrLn $ "number of events: " <> show (length evs)

--- a/log/app/testApp/Main.hs
+++ b/log/app/testApp/Main.hs
@@ -10,7 +10,7 @@ import Data.Foldable (for_)
 import Debug.Trace (flushEventLog, traceEventIO)
 import Foreign.Ptr (FunPtr)
 import GHC.Eventlog.Socket (startWait)
-import qualified Graphics.UI.Gtk as Gtk
+-- import qualified Graphics.UI.Gtk as Gtk
 
 foreign import ccall safe "cbit.h callTest" c_callTest :: IO ()
 
@@ -32,29 +32,9 @@ main = do
     forever $ do
       threadDelay 1_000_000
       flushEventLog
-  --forkIO $
   forever $ do
     threadDelay 5_000_000
     putStrLn "am i here"
-    for_ [1..10000] $ \_ ->
+    for_ [1..10_000] $ \_ ->
       -- c_callTest
       c_callTest2 wSimpleAction
-
-  {- _ <- Gtk.initGUI
-  window <- Gtk.windowNew
-  box <- Gtk.vBoxNew False 0
-  Gtk.containerAdd window box
-  cvs <- Gtk.drawingAreaNew
-  Gtk.boxPackStart box cvs Gtk.PackGrow 0
-  {- _ <- cvs `Gtk.on` Gtk.motionNotifyEvent $
-    Gtk.tryEvent $ do
-      liftIO $ traceEventIO "user event"
-  Gtk.widgetAddEvents cvs [Gtk.PointerMotionMask, Gtk.Button1MotionMask, Gtk.KeyPressMask]
-
-  _ <- cvs `Gtk.on` Gtk.buttonPressEvent $
-    Gtk.tryEvent $ do
-      liftIO $ traceEventIO "user event"
-  -}
-  Gtk.widgetShowAll window
-  Gtk.mainGUI
-  -}

--- a/log/app/testApp/Main.hs
+++ b/log/app/testApp/Main.hs
@@ -36,9 +36,9 @@ main = do
   forever $ do
     threadDelay 5_000_000
     putStrLn "am i here"
-    for_ [1..100000] $ \_ ->
-      c_callTest
-    -- c_callTest2 wSimpleAction
+    for_ [1..10000] $ \_ ->
+      -- c_callTest
+      c_callTest2 wSimpleAction
 
   {- _ <- Gtk.initGUI
   window <- Gtk.windowNew

--- a/log/app/testApp/Main.hs
+++ b/log/app/testApp/Main.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# OPTIONS_GHC -w #-}
+module Main where
+
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Monad (forever)
+import Control.Monad.IO.Class (liftIO)
+import Data.Foldable (for_)
+import Debug.Trace (flushEventLog, traceEventIO)
+import Foreign.Ptr (FunPtr)
+import GHC.Eventlog.Socket (startWait)
+import qualified Graphics.UI.Gtk as Gtk
+
+foreign import ccall safe "cbit.h callTest" c_callTest :: IO ()
+
+type SimpleIO = IO ()
+
+foreign import ccall "wrapper" mkWrapper :: SimpleIO -> IO (FunPtr SimpleIO)
+
+foreign import ccall safe "cbit.h callTest2" c_callTest2 :: FunPtr SimpleIO -> IO ()
+
+simpleAction :: IO ()
+simpleAction =
+  putStrLn "I am in simple action!"
+
+main :: IO ()
+main = do
+  startWait "/tmp/eventlog.sock"
+  wSimpleAction <- mkWrapper simpleAction
+  forkIO $
+    forever $ do
+      threadDelay 1_000_000
+      flushEventLog
+  --forkIO $
+  forever $ do
+    threadDelay 5_000_000
+    putStrLn "am i here"
+    for_ [1..100000] $ \_ ->
+      c_callTest
+    -- c_callTest2 wSimpleAction
+
+  {- _ <- Gtk.initGUI
+  window <- Gtk.windowNew
+  box <- Gtk.vBoxNew False 0
+  Gtk.containerAdd window box
+  cvs <- Gtk.drawingAreaNew
+  Gtk.boxPackStart box cvs Gtk.PackGrow 0
+  {- _ <- cvs `Gtk.on` Gtk.motionNotifyEvent $
+    Gtk.tryEvent $ do
+      liftIO $ traceEventIO "user event"
+  Gtk.widgetAddEvents cvs [Gtk.PointerMotionMask, Gtk.Button1MotionMask, Gtk.KeyPressMask]
+
+  _ <- cvs `Gtk.on` Gtk.buttonPressEvent $
+    Gtk.tryEvent $ do
+      liftIO $ traceEventIO "user event"
+  -}
+  Gtk.widgetShowAll window
+  Gtk.mainGUI
+  -}

--- a/log/app/testApp/Main.hs
+++ b/log/app/testApp/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# OPTIONS_GHC -w #-}
+
 module Main where
 
 import Control.Concurrent (forkIO, threadDelay)
@@ -10,7 +11,6 @@ import Data.Foldable (for_)
 import Debug.Trace (flushEventLog, traceEventIO)
 import Foreign.Ptr (FunPtr)
 import GHC.Eventlog.Socket (startWait)
--- import qualified Graphics.UI.Gtk as Gtk
 
 foreign import ccall safe "cbit.h callTest" c_callTest :: IO ()
 
@@ -35,6 +35,5 @@ main = do
   forever $ do
     threadDelay 5_000_000
     putStrLn "am i here"
-    for_ [1..10_000] $ \_ ->
-      -- c_callTest
+    for_ [1 .. 10_000] $ \_ ->
       c_callTest2 wSimpleAction

--- a/log/app/testApp/cbit.c
+++ b/log/app/testApp/cbit.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include "cbit.h"
+
+void callTest () {
+  printf("hello there!!\n");
+  fflush(stdout);
+}
+
+void callTest2 (void (*f) ()) {
+  printf("callTest2:\n");
+  f();
+  fflush(stdout);
+}

--- a/log/app/testApp/cbit.h
+++ b/log/app/testApp/cbit.h
@@ -1,0 +1,1 @@
+void callTest ();

--- a/log/hoodle-log.cabal
+++ b/log/hoodle-log.cabal
@@ -1,0 +1,28 @@
+Name:		hoodle-log
+Version:	1.0
+Synopsis:	logging
+Description: 	logging
+Homepage:       http://ianwookim.org/hoodle
+License: 	GPL-3
+License-file:	LICENSE
+Author:		Ian-Woo Kim
+Maintainer: 	Ian-Woo Kim <ianwookim@gmail.com>
+Category:       Application
+Tested-with:    GHC == 8.6
+Build-Type: 	Simple
+Cabal-Version:  2.0
+data-files:     CHANGES
+Source-repository head
+  type: git
+  location: http://www.github.com/wavewave/hoodle
+
+Executable logcat
+  Main-is:        Main.hs
+  hs-source-dirs: app/logcat
+  ghc-options: 	  -Wall -Werror -threaded -rtsopts
+  Build-Depends:
+                  base == 4.*,
+                  bytestring,
+                  ghc-events,
+                  network,
+                  pretty-simple

--- a/log/hoodle-log.cabal
+++ b/log/hoodle-log.cabal
@@ -26,3 +26,15 @@ Executable logcat
                   ghc-events,
                   network,
                   pretty-simple
+
+Executable testApp
+  Main-is:        Main.hs
+  hs-source-dirs: app/testApp
+  c-sources:      app/testApp/cbit.c
+  includes:       app/testApp/cbit.h
+  ghc-options: 	  -Wall -Werror -threaded -rtsopts
+  Build-Depends:
+                  base == 4.*,
+                  eventlog-socket,
+                  gtk3,
+                  transformers


### PR DESCRIPTION
Hoodle now generates GHC eventlogs, for example, StartThread, StopThread, StartGC and so on, using eventlog-socket library which uses the RTS EventlogWriter hook.
This PR introduces a simple tool `logcat` to print out the received eventlogs.