### PR TITLE
gi-gtk on GHC 9.2, 9.4 and GHC HEAD

### DIFF
--- a/cabal.project.local.ghcHEAD
+++ b/cabal.project.local.ghcHEAD
@@ -17,6 +17,8 @@ source-repository-package
         location: https://github.com/wavewave/ghc-eventlog-socket.git
         tag: ef3ac4b6c65f493ce1549d9f842e7a434a9db4a2
 
+-- gtk2hs
+
 source-repository-package
         type: git
         location: https://github.com/gtk2hs/gtk2hs.git
@@ -57,6 +59,19 @@ source-repository-package
         type: git
         location: https://github.com/dalpd/svgcairo.git
         tag: d1e0d7ae04c1edca83d5b782e464524cdda6ae85
+
+-- gi-gtk
+
+source-repository-package
+        type: git
+        location: https://github.com/wavewave/haskell-gi.git
+        tag: 63e1aa2694213f77c7d1ca50af899497205905ef
+        subdir: base
+
+source-repository-package
+        type: git
+        location: https://github.com/wavewave/haskell-gi.git
+        tag: 63e1aa2694213f77c7d1ca50af899497205905ef
 
 allow-newer:
   Cabal,

--- a/log/hoodle-log.cabal
+++ b/log/hoodle-log.cabal
@@ -24,6 +24,7 @@ Executable logcat
                   base == 4.*,
                   bytestring,
                   ghc-events,
+                  gi-gtk,
                   network,
                   pretty-simple
 

--- a/nix/ghc_nix.nix
+++ b/nix/ghc_nix.nix
@@ -23,7 +23,7 @@
         pkgs.xorg.libXtst
         pkgs.pkgconfig
       ]
-      ++ pkgs.lib.optional pkgs.stdenv.isLinux [pkgs.libselinux pkgs.libsepol pkgs.util-linux.dev];
+      ++ pkgs.lib.optional pkgs.stdenv.isLinux [pkgs.libselinux.dev pkgs.libsepol.dev pkgs.util-linux.dev];
 
     shellHook = ''
       export PS1="\n[hoodle-ghc.nix:\w]$ \0"

--- a/nix/ghc_nix.nix
+++ b/nix/ghc_nix.nix
@@ -10,6 +10,7 @@
       ++ [
         pkgs.epoxy.dev
         pkgs.gd
+        pkgs.gobject-introspection
         pkgs.gtk3
         pkgs.libdatrie
         pkgs.libdeflate

--- a/nix/gtk.nix
+++ b/nix/gtk.nix
@@ -25,6 +25,7 @@
       hoodlePackages);
 
   conf94 = hself: hsuper: {
+    # gtk2hs
     gio = let
       gio_t = haskellLib.addPkgconfigDepend hsuper.gio pkgs.pcre2;
     in
@@ -64,6 +65,103 @@
       pkgs.libdeflate
       pkgs.xorg.libXdmcp.dev
     ];
+
+    # gi-gtk
+    haskell-gi-base = haskellLib.addPkgconfigDepends hsuper.haskell-gi-base [
+      pkgs.pcre2
+    ];
+    haskell-gi = haskellLib.addPkgconfigDepends hsuper.haskell-gi [
+      pkgs.pcre2
+    ];
+    gi-cairo = haskellLib.addPkgconfigDepends hsuper.gi-cairo [
+      pkgs.pcre2
+      pkgs.xorg.libXdmcp.dev
+    ];
+    gi-glib = haskellLib.addPkgconfigDepends hsuper.gi-glib [
+      pkgs.pcre2
+    ];
+    gi-gmodule = haskellLib.addPkgconfigDepends hsuper.gi-gmodule [
+      pkgs.pcre2
+    ];
+    gi-gobject = haskellLib.addPkgconfigDepends hsuper.gi-gobject [
+      pkgs.pcre2
+    ];
+    gi-atk = haskellLib.addPkgconfigDepends hsuper.gi-atk [
+      pkgs.pcre2
+    ];
+    gi-harfbuzz = haskellLib.addPkgconfigDepends hsuper.gi-harfbuzz [
+      pkgs.freetype
+      pkgs.pcre2
+    ];
+    gi-gio = let
+      gi-gio_t = haskellLib.addPkgconfigDepend hsuper.gi-gio pkgs.pcre2;
+    in
+      haskellLib.addExtraLibraries gi-gio_t
+      [
+        pkgs.util-linux.dev
+        pkgs.libselinux
+        pkgs.libsepol
+        pkgs.pcre
+      ];
+    gi-pango = let
+      gi-pango_t = haskellLib.addPkgconfigDepend hsuper.gi-pango pkgs.pcre2;
+    in
+      haskellLib.addExtraLibraries gi-pango_t
+      [
+        pkgs.util-linux.dev
+        pkgs.libselinux
+        pkgs.libsepol
+        pkgs.pcre
+        pkgs.fribidi
+        pkgs.libthai
+        pkgs.libdatrie
+        pkgs.xorg.libXdmcp.dev
+      ];
+    gi-gdkpixbuf = let
+      gi-gdkpixbuf_t =
+        haskellLib.addPkgconfigDepend hsuper.gi-gdkpixbuf pkgs.pcre2;
+    in
+      haskellLib.addExtraLibraries gi-gdkpixbuf_t
+      [
+        pkgs.util-linux.dev
+        pkgs.libselinux
+        pkgs.libsepol
+        pkgs.pcre
+        pkgs.libdeflate
+      ];
+    gi-gdk = let
+      gi-gdk_t = haskellLib.addPkgconfigDepend hsuper.gi-gdk pkgs.pcre2;
+    in
+      haskellLib.addExtraLibraries gi-gdk_t
+      [
+        pkgs.util-linux.dev
+        pkgs.libselinux
+        pkgs.libsepol
+        pkgs.pcre
+        pkgs.libthai
+        pkgs.libdatrie
+        pkgs.xorg.libXdmcp.dev
+        pkgs.libdeflate
+        pkgs.libxkbcommon.dev
+        pkgs.epoxy.dev
+      ];
+    gi-gtk = let
+      gi-gtk_t = haskellLib.addPkgconfigDepend hsuper.gi-gtk pkgs.pcre2;
+    in
+      haskellLib.addExtraLibraries gi-gtk_t
+      [
+        pkgs.util-linux.dev
+        pkgs.libselinux
+        pkgs.libsepol
+        pkgs.pcre
+        pkgs.libthai
+        pkgs.libdatrie
+        pkgs.xorg.libXdmcp.dev
+        pkgs.libdeflate
+        pkgs.libxkbcommon.dev
+        pkgs.epoxy.dev
+        pkgs.xorg.libXtst
+      ];
   };
 
   hpkgsFor = compiler: let


### PR DESCRIPTION
gi-gtk is installed on gtk.ghc925, gtk.ghc944 and buildable on GHC HEAD by simple cabal.project.local without any 
 other adjustment.